### PR TITLE
Replace new line with space (instead of empty string)

### DIFF
--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -698,7 +698,8 @@ def varname(var_name):
     return var_name
 
 def oneline(text):
-    text = newlines.sub(r'', text)
+    '''Replaces all new line characters with a space'''
+    text = newlines.sub(r' ', text)
     return text
 
 def to_yaml_file(text):


### PR DESCRIPTION
Otherwise words or sentences will be missing spaces.