### PR TITLE
Add attorney_of_record_address_on_one_line as whole reserved word

### DIFF
--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -743,6 +743,7 @@ import re
 # Words that are reserved exactly as they are
 reserved_whole_words = [
   'signature_date',  # this is the plural version of this?
+  'attorney_of_record_address_on_one_line', 
 ]
 
 # Part of handling plural labels

--- a/docassemble/assemblylinewizard/map_names_test.py
+++ b/docassemble/assemblylinewizard/map_names_test.py
@@ -40,6 +40,7 @@ if __name__ == '__main__':
 scenarios = {
   # Reserved whole words
   "signature_date": "signature_date",
+  "attorney_of_record_address_on_one_line": "attorney_of_record_address_on_one_line",
   
   # Reserved endings
   "user1": "str(users[1-1])",


### PR DESCRIPTION
Fixes enhancement requested in #21