### PR TITLE
Allow docx arbitrary attributes. Fixes #81

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -260,6 +260,8 @@ code: |
       else:                
         new_field = fields.appendObject()
       fill_in_docx_field_attributes(new_field, field)
+      
+      log(new_field, 'console')
     
   get_all_fields = True
 ---

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -260,8 +260,6 @@ code: |
       else:                
         new_field = fields.appendObject()
       fill_in_docx_field_attributes(new_field, field)
-      
-      log(new_field, 'console')
     
   get_all_fields = True
 ---

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1087,24 +1087,40 @@ def is_reserved_docx_label(label):
     if label in reserved_whole_words:
         return True
 
-    # Is this a standalone reserved object reference, like `users` or `other_parties`?
-    if label in reserved_pluralizers_map.values():
-        return True
+    # If the complete string is a known prefix with or without brackets and nothing else?
+    if re.sub('\[.*\]$', '', label) in reserved_pluralizers_map.values():
+      return True
     
-    # Is this a reserved object reference with a list index?
-    reserved_with_list_index_regex = r'^' + '\[.*\]|'.join(reserved_pluralizers_map.values())
-    if re.match(reserved_with_list_index_regex, label):
-        return True
-
-    # Does the beginning of the variable name match a reserved name?
-    reserved_beginning_regex = r'(^' + '|'.join(reserved_var_plurals) + ')'
-
-    # Does the ending matching a reserved name?
-    # Note the ending list includes the . already
-    ending_reserved_regex = '(' + '|'.join(list(filter(None,reserved_suffixes_map.values()))).replace('(',r'\(').replace(')',r'\)').replace('.',r'\.')
-    ending_reserved_regex += '|' + '|'.join(docx_only_suffixes) + ')'
-
-    return re.match(reserved_beginning_regex + '(.*)' + ending_reserved_regex, label)
+    # If the complete string has a known prefix, get the rest of the string
+    # Does not control for really messed up variable name attempts
+    endOfKnownPrefix = re.findall(r'.*\[.*\]\..+', label);
+    
+    # If the complete string a combination of a known prefix and known suffix
+    if len(endOfKnownPrefix) === 1
+      && ( endOfKnownPrefix[0] in reserved_suffixes_map.values()
+        or endOfKnownPrefix[0] in docx_only_suffixes ):
+      return True;
+      
+    return False;
+  
+#    # Is this a standalone reserved object reference, like `users` or `other_parties`?
+#    if label in reserved_pluralizers_map.values():
+#        return True
+#    
+#    # Is this a reserved object reference with a list index?
+#    reserved_with_list_index_regex = r'^' + '\[.*\]|'.join(reserved_pluralizers_map.values())
+#    if re.match(reserved_with_list_index_regex, label):
+#        return True
+#    
+#    # Does the beginning of the variable name match a reserved name?
+#    reserved_beginning_regex = r'(^' + '|'.join(reserved_var_plurals) + ')'
+#    
+#    # Does the ending matching a reserved name?
+#    # Note the ending list includes the . already
+#    ending_reserved_regex = '(' + '|'.join(list(filter(None,reserved_suffixes_map.values()))).replace('(',r'\(').replace(')',r'\)').replace('.',r'\.')
+#    ending_reserved_regex += '|' + '|'.join(docx_only_suffixes) + ')'
+#    
+#    return re.match(reserved_beginning_regex + '(.*)' + ending_reserved_regex, label)
 
 def get_regex():
     reserved_beginning_regex = r'(^' + '|'.join(reserved_var_plurals) + ')'

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1085,22 +1085,31 @@ def is_reserved_docx_label(label):
     is_reserved = False
 
     if label in reserved_whole_words:
+        print('whole word true')
         return True
-
-    # If the complete string is a known prefix with or without brackets and nothing else?
-    if re.sub('\[.*\]$', '', label) in reserved_pluralizers_map.values():
-      return True
     
-    # If the complete string has a known prefix, get the rest of the string
-    # Does not control for really messed up variable name attempts
-    afterKnownPrefix = re.findall(r'.*\[.*\]\..+', label);
+    # just prefix working so far
+    print('~ just prefix ~')
+    print(re.sub('.+\[.*\]$', '', label) or 'full replace')
+    # If the complete string is a known prefix with or #without brackets and nothing else
+    withoutPrefix = re.sub('.+\[.*\]$', '', label)
+    if len(withoutPrefix) == 0 or withoutPrefix in reserved_pluralizers_map.values():
+        print('prefix true')
+        return True
     
-    # If the complete string a combination of a known prefix and known suffix
+    # If the complete string has a known prefix, get the #rest of the string
+    # Does not control for really messed up variable name #attempts
+    afterKnownPrefix = re.findall(r'.*\[.*\](\..+)', label)
+    print('~ just suffix ~')
+    print(afterKnownPrefix)
+    
+    # If the complete is string a combination of a known #prefix and known suffix
     if ( len(afterKnownPrefix) == 1
-      and ( afterKnownPrefix[0] in reserved_suffixes_map.values()
+     and ( afterKnownPrefix[0] in reserved_suffixes_map.values()
         or afterKnownPrefix[0] in docx_only_suffixes )):
-      return True;
-      
+     return True;
+     print('suffix true')
+     
     return False;
   
 #    # Is this a standalone reserved object reference, like `users` or `other_parties`?

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -842,7 +842,8 @@ def get_fields(the_file, include_attributes=False):
       result = fp.read()
       fields = set()
       addresses = r"(\b\S*)(((\.address_block\(\))|(\.address\.on_one_line())))"
-      methods = r"(.*)(\..*\(\))"
+      methods = r"(.*)(\..*\(.*\))"
+      
       # look for variables inside {{ }} tags
       for variable in re.findall(r'{{ *([^\} ]+) *}}', result): # look for all regular fields
         variable = variable.replace("\\","").replace('\n',"") # Filter out any new lines
@@ -881,7 +882,8 @@ def get_fields(the_file, include_attributes=False):
         else:
           if variable.isidentifier():           
             fields.add(variable)
-        del matches        
+        del matches
+        
     return [x for x in fields if not "(" in x] # strip out functions/method calls
 
 ########################################################

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1093,12 +1093,12 @@ def is_reserved_docx_label(label):
     
     # If the complete string has a known prefix, get the rest of the string
     # Does not control for really messed up variable name attempts
-    endOfKnownPrefix = re.findall(r'.*\[.*\]\..+', label);
+    afterKnownPrefix = re.findall(r'.*\[.*\]\..+', label);
     
     # If the complete string a combination of a known prefix and known suffix
-    if len(endOfKnownPrefix) === 1
-      && ( endOfKnownPrefix[0] in reserved_suffixes_map.values()
-        or endOfKnownPrefix[0] in docx_only_suffixes ):
+    if ( len(afterKnownPrefix) == 1
+      and ( afterKnownPrefix[0] in reserved_suffixes_map.values()
+        or afterKnownPrefix[0] in docx_only_suffixes )):
       return True;
       
     return False;

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1082,17 +1082,18 @@ def map_names(label, document_type="pdf"):
     else: result = combo
 
     return result
-
-# Regex for finding all exact matches of docx suffixes
-docx_only_suffixes_regex = '^' + '$|^'.join(docx_only_suffixes) + '$'
+  
 
 def is_reserved_docx_label(label):
+    '''Given a string, will return whether the string matches
+      reserved variable names. `label` must be a string.'''
     if label in reserved_whole_words:
         return True
 
     # Everything before the first period and everything from the first period to the end
     label_parts = re.findall(r'([^.]*)(\..*)*', label)
 
+    if not label_parts[0]: return False  # test for existance (empty strings result in a tuple) 
     # The prefix, ensuring no key or index
     prefix = re.sub(r'\[.+\]', '', label_parts[0][0])
     has_reserved_prefix = prefix in reserved_pluralizers_map.values()
@@ -1102,6 +1103,8 @@ def is_reserved_docx_label(label):
       if not suffix:  # If only the prefix
         return True
       # If the suffix is also reserved
+      # Regex for finding all exact matches of docx suffixes
+      docx_only_suffixes_regex = '^' + '$|^'.join(docx_only_suffixes) + '$'
       docx_suffixes_matches = re.findall(docx_only_suffixes_regex, suffix)
       if (suffix in reserved_suffixes_map.values()
         or len(docx_suffixes_matches) > 0 ):

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1081,34 +1081,29 @@ def map_names(label, document_type="pdf"):
 
     return result
 
+docx_only_suffixes_regex = '|'.join(docx_only_suffixes)
+  
 def is_reserved_docx_label(label):
-    is_reserved = False
+    #is_reserved = False
 
+    docassemble.base.functions.log( label, 'console' )
     if label in reserved_whole_words:
-        print('whole word true')
         return True
     
-    # just prefix working so far
-    print('~ just prefix ~')
-    print(re.sub('.+\[.*\]$', '', label) or 'full replace')
     # If the complete string is a known prefix with or #without brackets and nothing else
     withoutPrefix = re.sub('.+\[.*\]$', '', label)
     if len(withoutPrefix) == 0 or withoutPrefix in reserved_pluralizers_map.values():
-        print('prefix true')
         return True
     
     # If the complete string has a known prefix, get the #rest of the string
     # Does not control for really messed up variable name #attempts
     afterKnownPrefix = re.findall(r'.*\[.*\](\..+)', label)
-    print('~ just suffix ~')
-    print(afterKnownPrefix)
     
     # If the complete is string a combination of a known #prefix and known suffix
     if ( len(afterKnownPrefix) == 1
      and ( afterKnownPrefix[0] in reserved_suffixes_map.values()
-        or afterKnownPrefix[0] in docx_only_suffixes )):
+          or len(re.findall(docx_only_suffixes_regex, afterKnownPrefix[0])) > 0 )):
      return True;
-     print('suffix true')
      
     return False;
   


### PR DESCRIPTION
Fixes #81. This doesn't solve all the obstacles the docx var matching currently has, but it does solve this particular issue. See tests at https://repl.it/@plocket/docxvars#main.py and test with this Jinja:

```
Should NOT cause wizard prompts
{{users[0].email}}
{{users[0].address.address}}
{{users}}
{{users[0]}}
{{users[0].familiar_or()}}
{{users[0].birthdate.format("dd")}}
{{users[0].birthdate.format()}}

Causes wizard prompts because of unrelated functionality issues
{{users[0].address.block()}}

Should cause wizard prompts
{{users[0].mailing_address}}
{{user_has_name}}
{{users.number()}}
{{today()}}
```
