### PR TITLE
Interviews work with just basic questions

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -225,7 +225,7 @@ help: |
   might be the defendant, but in some cases you could be the plaintiff.
   
   If you are not sure: please review the form and talk to a subject matter 
-  expert. We can always fix this later.
+  expert. This can always be fixed later.
 ---
 comment: |
   Get the list of fields
@@ -249,9 +249,8 @@ code: |
     # Probably all of this should move into a class
     for pdf_field_tuple in all_fields:
       pdf_field_name = pdf_field_tuple[0]
-      # Check to see if we think this is a built-in field (a
-      # field handled in basic-questions.yml),
-      # a signature field, or an arbitrary field.
+      # Check to see if we think this field is built-in (handled in
+      # basic-questions.yml), a signature, or an arbitrary field.
       is_reserved_name = is_reserved_label(pdf_field_name)
       if is_reserved_name or pdf_field_name in variables_to_skip:
         new_field = built_in_fields_used.appendObject()
@@ -529,7 +528,7 @@ code: |
   review_block.type = "review"
   # Add the fields, removing any duplicates by assigning to a dict first
   review_block.field_list = fields + built_in_fields_used + signature_fields
-  review_block.question_text = "Placeholder Review Screen"
+  review_block.question_text = "Review Screen"
   review_block.subquestion_text = "Edit your answers below"
   review_block.id = interview_label + ' review screen'
   review_block.event = "review_" + interview_label

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -184,7 +184,7 @@ fields:
     hint: http://masslegalhelp.org/my_form
     required: False
 help: |
-  ${len(all_fields)}
+  There are ${len(all_fields)} fields total.
   
   `${all_fields}`
   
@@ -376,7 +376,7 @@ continue button field: choose_field_types
 question: |
   On-screen prompts
 subquestion: |  
-
+  % if len(field_question) > 0:
   1. Look at each field below. It represents a blank space on your template.
   1. If the field is handled as a "basic question", it will not be shown
   below. Instead, we will use a pre-written prompt for it.
@@ -389,6 +389,7 @@ subquestion: |
   * `text` is a normal text field. `area` is a text field with more room (3 lines by default)
   * `integer` is a whole number, while `number` can have a decimal point. `currency` represents a dollar figure
   * `date` is a standard date picker, which shows a calendar in most browsers.
+  % endif
     
 fields:
   - code: field_question
@@ -405,7 +406,7 @@ fields:
         len(built_in_fields_used)
 ---
 code: |
-  questions.there_are_any = len(all_fields) > 0
+  questions.there_are_any = len(fields) > 0
 ---
 code: |
   # We keep adding questions until ALL of the fields have been

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -381,7 +381,7 @@ class DAQuestion(DAObject):
             # move into the interview YAML or a separate module/subclass
             content += "id: interview_order_" + self.interview_label + "\n"
             content += "code: |\n"
-            content += "  # This is a placeholder to control logic flow in this interview" + "\n"
+            content += "  # This controls logic flow in this interview" + "\n"
             content += "\n  basic_questions_intro_screen \n" # trigger asking any intro questions at start of interview
             content += "  " + self.interview_label + "_intro" + "\n"
             signatures = set()

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -527,24 +527,24 @@ class DAQuestion(DAObject):
         return content
 
 class DAQuestionList(DAList):
-  """This represents a list of DAQuestions."""
-  def init(self, **kwargs):
-    super().init(**kwargs)
-    self.object_type = DAQuestion
-    # self.auto_gather = False
-    # self.gathered = True
-    # self.is_mandatory = False
+    """This represents a list of DAQuestions."""
+    def init(self, **kwargs):
+        super().init(**kwargs)
+        self.object_type = DAQuestion
+        # self.auto_gather = False
+        # self.gathered = True
+        # self.is_mandatory = False
 
-  def all_fields_used(self):
-    """This method is used to help us iteratively build a list of fields that have already been assigned to a screen/question
-      in our wizarding process. It makes sure the fields aren't displayed to the wizard user on multiple screens.
-      It prevents the formatter of the wizard from putting the same fields on two different screens."""
-    fields = set()
-    for question in self.elements:
-      if hasattr(question,'field_list'):
-        for field in question.field_list.elements:
-          fields.add(field)
-    return fields
+    def all_fields_used(self):
+        """This method is used to help us iteratively build a list of fields that have already been assigned to a screen/question
+        in our wizarding process. It makes sure the fields aren't displayed to the wizard user on multiple screens.
+        It prevents the formatter of the wizard from putting the same fields on two different screens."""
+        fields = set()
+        for question in self.elements:
+            if hasattr(question,'field_list'):
+                for field in question.field_list.elements:
+                    fields.add(field)
+        return fields
 
 class PlaygroundSection(object):
     def __init__(self, section='', project='default'):


### PR DESCRIPTION
Fixes:
* #114 
* #35 

If all questions are covered by basic questions, it spares the users from all of the specific details of setting types, and the screen looks like this instead:

![Screenshot from 2021-01-22 17-12-11](https://user-images.githubusercontent.com/6252212/105554426-593ea800-5cd5-11eb-9fb8-694ce36185e1.png)


Tested using this variant on the hello world docx: [hello_planet2.docx](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/5858927/hello_planet2.docx)
