### PR TITLE
Adds missing leading `.`s to DOCX only suffixes

### DIFF
--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -150,8 +150,8 @@ generator_constants.DOCX_ONLY_SUFFIXES = [
     r'.birthdate.format\(.*\)',
     r'.familiar\(\)',
     r'.familiar_or\(\)',
-    r'phone_numbers\(\)',
-    r'formatted_age\(\)'
+    r'.phone_numbers\(\)',
+    r'.formatted_age\(\)'
 ]
 
 generator_constants.UNMAP_SUFFIXES = {

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -146,12 +146,12 @@ generator_constants.RESERVED_SUFFIXES_MAP = {**generator_constants.PEOPLE_SUFFIX
 # these might be used in a docx, but we don't transform PDF fields to use these
 # suffixes
 generator_constants.DOCX_ONLY_SUFFIXES = [
-    r'.birthdate',
-    r'.birthdate.format\(.*\)',
-    r'.familiar\(\)',
-    r'.familiar_or\(\)',
-    r'.phone_numbers\(\)',
-    r'.formatted_age\(\)'
+    r'\.birthdate',
+    r'\.birthdate.format\(.*\)',
+    r'\.familiar\(\)',
+    r'\.familiar_or\(\)',
+    r'\.phone_numbers\(\)',
+    r'\.formatted_age\(\)'
 ]
 
 generator_constants.UNMAP_SUFFIXES = {


### PR DESCRIPTION
Noted here: https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/pull/143/files/efb1b6a167aa827028aa5f6cd8aade3080572096#r56536262