### PR TITLE
Close #67, add `mail_address` to reserved suffixes

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -539,7 +539,7 @@ code: |
       # Add the first field in every question to our logic tree
       # This can be customized to control the order of questions later      
       if hasattr(question, 'has_mandatory_field') and question.has_mandatory_field:
-        logic_list.append(question.field_list[0].transformed_variable)
+        logic_list.append(question.field_list[0].docassemble_variable)
       else:
         logic_list.append(varname(question.question_text))
 

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -177,4 +177,8 @@ generator_constants.UNMAP_SUFFIXES = {
   ".address.on_one_line()": ".address.address",
   ".address.line_one()": ".address.address",
   ".address.line_two()": ".address.address",
+  ".mail_address.block()": ".mail_address.address",
+  ".mail_address.on_one_line()": ".mail_address.address",
+  ".mail_address.line_one()": ".mail_address.address",
+  ".mail_address.line_two()": ".mail_address.address",
 }

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -132,7 +132,20 @@ generator_constants.PEOPLE_SUFFIXES_MAP = {
   '_address_line_one': ".address.line_one()",
   '_address_city_state_zip': ".address.line_two()",
   '_signature': ".signature",
-  '_mail_address': ".mail_address"
+  '_mail_address_block': ".mail_address.block()",
+  '_mail_address_street': ".mail_address.address",
+  '_mail_address_street2': ".mail_address.unit",
+  '_mail_address_address': ".mail_address.address",
+  '_mail_address_unit': ".mail_address.unit",
+  '_mail_address_city': ".mail_address.city",
+  '_mail_address_state': ".mail_address.state",
+  '_mail_address_zip': ".mail_address.zip",
+  '_mail_address_county': ".mail_address.county",
+  '_mail_address_country': ".mail_address.country",
+  '_mail_address_on_one_line': ".mail_address.on_one_line()",
+  '_mail_address_line_one': ".mail_address.line_one()",
+  '_mail_address_city_state_zip': ".mail_address.line_two()",
+  '_mail_address': ".mail_address",
 }
 
 generator_constants.PEOPLE_SUFFIXES = list(generator_constants.PEOPLE_SUFFIXES_MAP.values()) + ['.name.full()','.name']

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -132,6 +132,7 @@ generator_constants.PEOPLE_SUFFIXES_MAP = {
   '_address_line_one': ".address.line_one()",
   '_address_city_state_zip': ".address.line_two()",
   '_signature': ".signature",
+  '_mail_address': ".mail_address"
 }
 
 generator_constants.PEOPLE_SUFFIXES = list(generator_constants.PEOPLE_SUFFIXES_MAP.values()) + ['.name.full()','.name']

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -884,6 +884,14 @@ def get_docx_variables( text ):
         fields.add( re.sub(r'\.address.*', '.address.address', possible_var ))
       fields.add( prefix_with_key )
       continue
+      
+    if '.mail_address' in possible_var:  # a mailing address
+      if '.mail_address.county' in possible_var:  # a county is special
+        fields.add( possible_var )
+      else:  # all other mailing addresses (replaces .zip and such)
+        fields.add( re.sub(r'\.mail_address.*', '.mail_address.address', possible_var ))
+      fields.add( prefix_with_key )
+      continue
 
     if '.name' in possible_var:  # a name
       if '.name.text' in possible_var:  # Names for non-Individuals

--- a/docassemble/assemblylinewizard/test_map_names.py
+++ b/docassemble/assemblylinewizard/test_map_names.py
@@ -37,6 +37,7 @@ attachment_scenarios = {
   "user_address_line_one": "users[0].address.line_one()",
   "user_address_city_state_zip": "users[0].address.line_two()",
   "user_signature": "users[0].signature",
+  "user_mail_address": "users[0].mail_address",
 
   # Combo all
   "user3_birthdate__4": "users[2].birthdate.format()",
@@ -123,6 +124,7 @@ interview_order_scenarios = {
   "user_email": "users[0].email",
   "user2_phone": "users[1].phone_number",
   "user_signature": "users[0].signature",
+  "user_mail_address": "users[0].mail_address",
 
   # County
   # "county_name_short": not implemented,

--- a/docassemble/assemblylinewizard/test_map_names.py
+++ b/docassemble/assemblylinewizard/test_map_names.py
@@ -38,6 +38,9 @@ attachment_scenarios = {
   "user_address_city_state_zip": "users[0].address.line_two()",
   "user_signature": "users[0].signature",
   "user_mail_address": "users[0].mail_address",
+  'user_mail_address_block': "users[0].mail_address.block()",
+  'user_mail_address_address': "users[0].mail_address.address",
+  'user_mail_address_zip': "users[0].mail_address.zip",
 
   # Combo all
   "user3_birthdate__4": "users[2].birthdate.format()",
@@ -125,6 +128,9 @@ interview_order_scenarios = {
   "user2_phone": "users[1].phone_number",
   "user_signature": "users[0].signature",
   "user_mail_address": "users[0].mail_address",
+  'user_mail_address_block': "users[0].mail_address",
+  'user_mail_address_address': "users[0].mail_address",
+  'user_mail_address_zip': "users[0].mail_address",
 
   # County
   # "county_name_short": not implemented,
@@ -197,7 +203,7 @@ class TestMapNames(unittest.TestCase):
                 passed.append(scenario_input)
             except AssertionError as error:
                 # The error should show us what specifically didn't match up
-                log(error + "\n", "console")
+                log(str(error) + "\n", "console")
                 log("~~~~~~~~~~\n", "console")
                 errored.append({"test": scenario_input, "result": error})
         return passed, errored

--- a/setup.py
+++ b/setup.py
@@ -57,3 +57,4 @@ setup(name='docassemble.assemblylinewizard',
       zip_safe=False,
       package_data=find_package_data(where='docassemble/assemblylinewizard/', package='docassemble.assemblylinewizard'),
      )
+


### PR DESCRIPTION
Closes #67

Test 1:
1. Run generator-test.yml to confirm it appears there and passes.

Test 2:
1. Upload the below PDF
1. See that there are no unreserved vars created
1. (Should we allow people to create info screens even if they're only using reserved vars?)
1. See that yaml includes the right vars in the attachment block and the right vars in the interview order

[mail_address.pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/5912318/mail_address.pdf)