### PR TITLE
Fix #157, until implemented remove const `attorney_of_record_address...`

### DIFF
--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -11,7 +11,7 @@ generator_constants = Object()
 # Words that are reserved exactly as they are
 generator_constants.RESERVED_WHOLE_WORDS = [
   'signature_date',  # this is the plural version of this?
-  'attorney_of_record_address_on_one_line',
+  #'attorney_of_record_address_on_one_line',
 ]
 
 # Vars representing people

--- a/docassemble/assemblylinewizard/test_map_names.py
+++ b/docassemble/assemblylinewizard/test_map_names.py
@@ -9,7 +9,8 @@ __all__ = ['TestMapNames']
 attachment_scenarios = {
   # Reserved whole words
   "signature_date": "signature_date",
-  "attorney_of_record_address_on_one_line": "attorney_of_record_address_on_one_line",
+  # Not yet implemented
+  #"attorney_of_record_address_on_one_line": "attorney_of_record_address_on_one_line",
 
   # Reserved endings
   "user1": "users[0]",
@@ -102,7 +103,8 @@ attachment_scenarios = {
 interview_order_scenarios = {
   # Reserved whole words
   "signature_date": "signature_date",
-  "attorney_of_record_address_on_one_line": "attorney_of_record_address_on_one_line",
+  # Not yet implemented
+  #"attorney_of_record_address_on_one_line": "attorney_of_record_address_on_one_line",
 
   # Reserved endings
   "user1": "users.gather()",

--- a/setup.py
+++ b/setup.py
@@ -57,3 +57,4 @@ setup(name='docassemble.assemblylinewizard',
       zip_safe=False,
       package_data=find_package_data(where='docassemble/assemblylinewizard/', package='docassemble.assemblylinewizard'),
      )
+


### PR DESCRIPTION
Fix #157

Try this PDF in the weaver to see that `attorney_of_record_address_on_one_line` is not treated as a reserved word:
[atty_of_record_add.pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/5904668/atty_of_record_add.pdf)
