### PR TITLE
Add objects block for all people in generated interview, allow limiting number of people to exactly 1

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -39,6 +39,7 @@ comment: |
   This is a list of some variables we leave alone (don't transform)
   but still represent something we're handling in basic-question.yml
   No need to prompt the user to group these questions.
+  # TODO: this is really handled in the generator constants now
 variable name: variables_to_skip
 data:
   - signature_date
@@ -70,6 +71,7 @@ code: |
   choose_field_types
   questions.gather()
   
+  add_objects_block
   add_logic_tree
   add_draft_intro_screen
   created_preview_question
@@ -236,6 +238,20 @@ subquestion: |
   The Plaintiff/Petitioner starts a case. The Defendant/Respondent
   is responding to a case someone else started.
 fields:
+  - note: |
+      The list of names below look like names for people, based on
+      how you use them in your document.
+    show if:
+      code: |
+        len(get_person_variables(all_fields, custom_only=True)) > 0
+  - Which variable names represent people?: people_variables
+    datatype: checkboxes
+    code: |
+      get_person_variables(all_fields, custom_only=True)
+    help: |
+      "person" variables will get things like addresses, multi-part
+      names, and proper questions handled automatically. Using them
+      will help you save time writing your interview.
   - User's role: interview.typical_role
     input type: radio
     choices:
@@ -504,6 +520,18 @@ code: |
     question.type = "question"
     interview.questions.append(question)
   add_questions_to_interview = True
+---
+code: |
+  objects_block =  interview.questions.appendObject()
+  objects_block.type = "objects"
+  objects_block.objects = DAList(object_type=DAObject, auto_gather=False)
+  for person in people_variables:
+    # TODO: ask how many of this object can be gathered and use it here
+    new_object = objects_block.appendObject()
+    new_object.name = person
+    new_object.type = "ALPeopleList"
+    # no parameters yet
+  add_objects_block = True
 ---
 code: |
   # Build the mandatory code block that will control question flow

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -63,6 +63,7 @@ code: |
   interview.title
   interview_intro_prompt
   interview.typical_role  
+  ask_people_quantity_question  
   add_includes
   set_metadata # Adds metadata block to the interview as first block
   add_short_title
@@ -275,6 +276,38 @@ help: |
   
   If you are not sure: please review the form and talk to a subject matter 
   expert. This can always be fixed later.
+---
+objects:
+  - people_quantities: DADict.using(auto_gather=False, gathered=True)
+---
+code: |
+  # Build the dynamic question code to ask about people quantities
+  temp_people_quantity_question = []
+  for person in people_variables.true_values().union(built_in_people_vars_used):
+    temp_people_quantity_question.append({"How many **" + person + "** can appear on this form?": "people_quantities['" + person + "']",
+      "datatype": "radio",
+      "choices": [{'Exactly 1': 'one'},{'One or more':'more'}]
+      })
+  people_quantity_question = temp_people_quantity_question
+  del temp_people_quantity_question
+---
+question: |
+  Information about people
+subquestion: |
+  This form includes the following variables representing people:
+  ${ comma_and_list(people_variables.true_values().union(built_in_people_vars_used)) }
+fields:
+  - code: people_quantity_question 
+help:
+  label: |
+    What is this about?
+  content: |
+    By default, all "person" variables are plural.
+    
+    If you only want one of each person type to ever use this form,
+    tell us here. You'll still be able to edit your file if you change
+    your mind later.
+continue button field: ask_people_quantity_question  
 ---
 comment: |
   Get the list of fields
@@ -531,11 +564,15 @@ code: |
   objects_block.type = "objects"
   objects_block.objects = DAList(object_type=DAObject, auto_gather=False)
   for person in people_variables.true_values().union(built_in_people_vars_used):
-    # TODO: ask how many of this object can be gathered and use it here
     new_object = objects_block.objects.appendObject()
     new_object.name = person
     new_object.type = "ALPeopleList"
-    # no parameters yet
+    if person in people_quantities:
+      if people_quantities[person] == 'one':
+        new_object.params = [
+          ("ask_number", "True", bool), 
+          ("target_number", 1, int)
+          ]
   objects_block.objects.gathered=True
   add_objects_block = True
 ---

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -284,6 +284,9 @@ code: |
   else:
     all_fields = get_fields(template_upload) # template_upload.get_docx_variables()
 ---
+code: |
+ built_in_people_vars_used = get_person_variables(all_fields, custom_only=False) - get_person_variables(all_fields, custom_only=True)
+---
 comment: |
   Convert the PDF fields into Docassemble fields
 code: |
@@ -521,16 +524,19 @@ code: |
     interview.questions.append(question)
   add_questions_to_interview = True
 ---
+need:
+  - built_in_people_vars_used
 code: |
   objects_block =  interview.questions.appendObject()
   objects_block.type = "objects"
   objects_block.objects = DAList(object_type=DAObject, auto_gather=False)
-  for person in people_variables:
+  for person in people_variables.true_values().union(built_in_people_vars_used):
     # TODO: ask how many of this object can be gathered and use it here
-    new_object = objects_block.appendObject()
+    new_object = objects_block.objects.appendObject()
     new_object.name = person
     new_object.type = "ALPeopleList"
     # no parameters yet
+  objects_block.objects.gathered=True
   add_objects_block = True
 ---
 code: |

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -71,7 +71,7 @@ generator_constants.RESERVED_PREFIXES = (r"^(user"  # deprecated, but still supp
 
 # reserved_pluralizers_map
 
-generator_constants.RESERVED_PLURALIZERS_MAP = {
+generator_constants.RESERVED_PERSON_PLURALIZERS_MAP = {
   'user': 'users',
   'plaintiff': 'plaintiffs',
   'defendant': 'defendants',
@@ -85,8 +85,6 @@ generator_constants.RESERVED_PLURALIZERS_MAP = {
   'translator': 'translators',
   'debt_collector': 'debt_collectors',
   'creditor': 'creditors',
-  'court': 'courts',
-  'docket_number': 'docket_numbers',
   # Non-s plurals
   'other_party': 'other_parties',
   'child': 'children',
@@ -95,6 +93,11 @@ generator_constants.RESERVED_PLURALIZERS_MAP = {
   'decedent': 'decedents',
   'interested_party': 'interested_parties',
 }
+
+generator_constants.RESERVED_PLURALIZERS_MAP = generator_constants.RESERVED_PERSON_PLURALIZERS_MAP.update({
+  'court': 'courts',
+  'docket_number': 'docket_numbers',
+})
 
 # Any reason to not make all suffixes available to everyone?
 # Yes: it can break variables that overlap but have a different meaning

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -94,10 +94,10 @@ generator_constants.RESERVED_PERSON_PLURALIZERS_MAP = {
   'interested_party': 'interested_parties',
 }
 
-generator_constants.RESERVED_PLURALIZERS_MAP = generator_constants.RESERVED_PERSON_PLURALIZERS_MAP.update({
+generator_constants.RESERVED_PLURALIZERS_MAP = {** generator_constants.RESERVED_PERSON_PLURALIZERS_MAP, **{
   'court': 'courts',
   'docket_number': 'docket_numbers',
-})
+}}
 
 # Any reason to not make all suffixes available to everyone?
 # Yes: it can break variables that overlap but have a different meaning

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -22,7 +22,7 @@ from .generator_constants import generator_constants
 
 TypeType = type(type(None))
 
-__all__ = ['Playground', 'PlaygroundSection', 'indent_by', 'varname', 'DAField', 'DAFieldList', 'DAQuestion', 'DAInterview', 'DAAttachmentList', 'DAAttachment', 'to_yaml_file', 'base_name', 'to_package_name', 'oneline', 'DAQuestionList', 'map_names', 'trigger_gather_string', 'is_reserved_label', 'fill_in_field_attributes', 'attachment_download_html', 'get_fields','is_reserved_docx_label','get_character_limit', 'create_package_zip', 'get_person_variables']
+__all__ = ['Playground', 'PlaygroundSection', 'indent_by', 'varname', 'DAField', 'DAFieldList', 'DAQuestion', 'DAInterview', 'DAAttachmentList', 'DAAttachment', 'to_yaml_file', 'base_name', 'to_package_name', 'oneline', 'DAQuestionList', 'map_names', 'trigger_gather_string', 'is_reserved_label', 'attachment_download_html', 'get_fields','is_reserved_docx_label','get_character_limit', 'create_package_zip', 'get_person_variables']
 
 always_defined = set(["False", "None", "True", "dict", "i", "list", "menu_items", "multi_user", "role", "role_event", "role_needed", "speak_text", "track_location", "url_args", "x", "nav", "PY2", "string_types"])
 replace_square_brackets = re.compile(r'\\\[ *([^\\]+)\\\]')

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -22,7 +22,7 @@ from .generator_constants import generator_constants
 
 TypeType = type(type(None))
 
-__all__ = ['Playground', 'PlaygroundSection', 'indent_by', 'varname', 'DAField', 'DAFieldList', 'DAQuestion', 'DAInterview', 'DAAttachmentList', 'DAAttachment', 'to_yaml_file', 'base_name', 'to_package_name', 'oneline', 'DAQuestionList', 'map_names', 'trigger_gather_string', 'is_reserved_label', 'fill_in_field_attributes', 'attachment_download_html', 'get_fields','fill_in_docx_field_attributes','is_reserved_docx_label','get_character_limit']
+__all__ = ['Playground', 'PlaygroundSection', 'indent_by', 'varname', 'DAField', 'DAFieldList', 'DAQuestion', 'DAInterview', 'DAAttachmentList', 'DAAttachment', 'to_yaml_file', 'base_name', 'to_package_name', 'oneline', 'DAQuestionList', 'map_names', 'trigger_gather_string', 'is_reserved_label', 'fill_in_field_attributes', 'attachment_download_html', 'get_fields','fill_in_docx_field_attributes','is_reserved_docx_label','get_character_limit','get_person_variables']
 
 always_defined = set(["False", "None", "True", "dict", "i", "list", "menu_items", "multi_user", "role", "role_event", "role_needed", "speak_text", "track_location", "url_args", "x", "nav", "PY2", "string_types"])
 replace_square_brackets = re.compile(r'\\\[ *([^\\]+)\\\]')
@@ -1107,44 +1107,33 @@ def indexify(digit):
   else:
     return '[' + str(int(digit)-1) + ']'
 
+# TODO: is this function used or necessary? Looks like no longer referenced
 def should_be_stringified(var_name):
-  has_no_attributes = var_name.find(".") == -1
+  has_no_attributes = not "." in var_name
   is_docket_number = var_name.startswith("docket_numbers[")
   return has_no_attributes and not is_docket_number
 
-def get_person_variables(fieldslist):
+def get_person_variables(fieldslist, people_vars=generator_constants.PEOPLE_VARS, people_suffixes = generator_constants.PEOPLE_SUFFIXES, people_suffixes_map = generator_constants.PEOPLE_SUFFIXES_MAP, custom_only=False):
   """
   Identify the field names that represent people in the list of
-  DAFields pulled from docx/PDF.
+  string fields pulled from docx/PDF.    
   """
   people = set()
   for field in fieldslist:
-    if is_person(field.variable):
-      people.add(get_person_identifier(field.variable))
-  return people
-
-def is_person(field_name, people_vars=generator_constants.PEOPLE_VARS):
-  """
-  Check if the field name appears to represent a person
-  """
-  # Is it exactly a person variable: e.g., `users`
-  if remove_string_wrapper(field_name) in people_vars:
-    return True
-  if '[' in field_name or '.' in field_name:
-    match_with_brackets_or_attribute = r"(\D\w*)((\[.*)|(\..*))"
-    matches = re.match(match_with_brackets_or_attribute, field_name)
-    if matches:
-      if matches.groups()[0] in people_vars:
-        return True
-      else:
-        endings = [
-          "[0].address_block()",
-          "[0].address.block()",
-          "[0].address.on_one_line()",
-          "[0].",
-        ]
-        if matches.groups()[1] in endings:
-            return True
-
-def get_person_identifier(field_name):
-  pass
+    if remove_string_wrapper(field) in people_vars:
+      people.add(field)
+    if '[' in field or '.' in field:
+      match_with_brackets_or_attribute = r"(\D\w*)((\[.*)|(\..*))"
+      matches = re.match(match_with_brackets_or_attribute, field)
+      if matches:
+        # Is the name before attribute/index a predetermined person?  
+        if matches.groups()[0] in people_vars:
+          people.add(matches.groups()[0])
+        else:
+          # Look for prefixes normally associated with people
+          if matches.groups()[1] in people_suffixes or matches.groups()[1] in list(people_suffixes_map.keys()) :
+            people.add(matches.groups()[0])
+  if custom_only:
+    return people - set(people_vars)
+  else:
+    return people

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1149,7 +1149,7 @@ def get_person_variables(fieldslist, people_vars=generator_constants.PEOPLE_VARS
   """
   people = set()
   for field in fieldslist:
-    # fields are tuples for PDF and strings for docx
+    # fields are currently tuples for PDF and strings for docx
     if isinstance(field, tuple):
       field_to_check = map_names(field[0])
     else:
@@ -1171,18 +1171,21 @@ def get_person_variables(fieldslist, people_vars=generator_constants.PEOPLE_VARS
           # Look for suffixes normally associated with people, like _name_first for PDF or .name.first for a DOCX, etc.
           if map_names(matches.groups()[1]) in people_suffixes:
             people.add(matches.groups()[0])
-    else:
-      # The regex below is non-greedy; _address will match before _mail_address
-      match_pdf_person_suffixes = r"([A-Za-z_]\w*)(" + "|".join(people_suffixes.keys()) + "$)"
-      matches = re.match(match_pdf_person_suffixes, field_to_check)
-      if matches:
-        # There may be more elegant solution. but since _mail_address_address
-        # will match _address_address this is workaround below.
-        # If we add more possible partial matches to suffixes, we need to add more workarounds
-        if matches.groups()[0].endswith('_mail') and matches.groups()[1].startswith('_address'):
-          people.add(matches.groups()[0][:-5])
-        else:          
-          people.add(matches.groups()[0])
+
+    # # Branch below in theory shouldn't be relevant since we do a map_names above on PDF fields
+    # # Leaving here in case we adjust the code for PDF/DOCX field scanning in the future and it was a pain to work out
+    # else:
+    #   # The regex below is non-greedy; _address will match before _mail_address
+    #   match_pdf_person_suffixes = r"([A-Za-z_]\w*)(" + "|".join(people_suffixes.keys()) + "$)"
+    #   matches = re.match(match_pdf_person_suffixes, field_to_check)
+    #   if matches:
+    #     # There may be more elegant solution. but since _mail_address_address
+    #     # will match _address_address this is workaround below.
+    #     # If we add more possible partial matches to suffixes, we need to add more workarounds
+    #     if matches.groups()[0].endswith('_mail') and matches.groups()[1].startswith('_address'):
+    #       people.add(matches.groups()[0][:-5])
+    #     else:          
+    #       people.add(matches.groups()[0])
   if custom_only:
     return people - set(people_vars)
   else:

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -417,7 +417,8 @@ class DAQuestion(DAObject):
                     param_string += json.dumps(str(param[1]))
                   params_string_builder.append(param_string)
                 content += ",".join(params_string_builder)
-                content += ")" 
+                content += ")"
+              content += "\n" 
             content += "\n"
                                    
         elif self.type == 'interview order':

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -401,15 +401,19 @@ class DAQuestion(DAObject):
               content += "  - " + object.name + ': ' + object.type
               if hasattr(object, 'params'):
                 content += ".using("
+                params_string_builder = []
                 for param in object.params:
-                  content += str(param[0]) + "="
+                  param_string = str(param[0]) + "="
                   if len(param) > 2:
                     # This might be an int value, other variable name, etc.
-                    content += str(param[1])
+                    param_string += str(param[1])
                   else:
                     # this is a normal string value and should get quoted.
                     # use json.dumps() to properly quote strings. shouldn't come up
-                    content += json.dumps(str(param[1]))
+                    param_string += json.dumps(str(param[1]))
+                  params_string_builder.append(param_string)
+                content += ",".join(params_string_builder)
+                content += ")" 
             content += "\n"
                                    
         elif self.type == 'interview order':

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1169,7 +1169,7 @@ def get_person_variables(fieldslist, people_vars=generator_constants.PEOPLE_VARS
         else:
           # Look for prefixes normally associated with people
           # TODO: double-check this is right for PDFs when it's just the suffix that's a clue
-          if map_names(matches.groups()[1]) in people_suffixes or matches.groups()[1] in list(people_suffixes_map.keys()):
+          if map_names(matches.groups()[1]) in people_suffixes or matches.groups()[1] in people_suffixes_map.keys():
             people.add(map_names(matches.groups()[0]))
   if custom_only:
     return people - set(people_vars)

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -388,7 +388,7 @@ class DAQuestion(DAObject):
                 content += "under: |\n" + indent_by(self.under_text, 2)
         elif self.type == 'code':
             content += "code: |\n" + indent_by(self.code, 2)
-        elif self.type == 'objects':
+        elif self.type == 'objects' and len(self.objects):
             # An object should be a list of DAObjects with the following attributes:
             # name, type, params [optional]
             # params is going to be a list/iterable object of two or 3 item tuples or lists 

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1171,21 +1171,19 @@ def get_person_variables(fieldslist, people_vars=generator_constants.PEOPLE_VARS
           # Look for suffixes normally associated with people, like _name_first for PDF or .name.first for a DOCX, etc.
           if map_names(matches.groups()[1]) in people_suffixes:
             people.add(matches.groups()[0])
-
-    # # Branch below in theory shouldn't be relevant since we do a map_names above on PDF fields
-    # # Leaving here in case we adjust the code for PDF/DOCX field scanning in the future and it was a pain to work out
-    # else:
-    #   # The regex below is non-greedy; _address will match before _mail_address
-    #   match_pdf_person_suffixes = r"([A-Za-z_]\w*)(" + "|".join(people_suffixes.keys()) + "$)"
-    #   matches = re.match(match_pdf_person_suffixes, field_to_check)
-    #   if matches:
-    #     # There may be more elegant solution. but since _mail_address_address
-    #     # will match _address_address this is workaround below.
-    #     # If we add more possible partial matches to suffixes, we need to add more workarounds
-    #     if matches.groups()[0].endswith('_mail') and matches.groups()[1].startswith('_address'):
-    #       people.add(matches.groups()[0][:-5])
-    #     else:          
-    #       people.add(matches.groups()[0])
+    else:
+      # If it's a PDF name that wasn't transformed by map_names, do one last check
+      # The regex below is non-greedy; _address will match before _mail_address
+      match_pdf_person_suffixes = r"([A-Za-z_]\w*)(" + "|".join(people_suffixes_map.keys()) + "$)"
+      matches = re.match(match_pdf_person_suffixes, field_to_check)
+      if matches:
+        # There may be more elegant solution. but since _mail_address_address
+        # will match _address_address this is workaround below.
+        # If we add more possible partial matches to suffixes, we need to add more workarounds
+        if matches.groups()[0].endswith('_mail') and matches.groups()[1].startswith('_address'):
+          people.add(matches.groups()[0][:-5])
+        else:          
+          people.add(matches.groups()[0])
   if custom_only:
     return people - set(people_vars)
   else:

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -17,6 +17,7 @@ import docassemble.base.pdftk
 import shutil
 import datetime
 import types
+import json
 # Get local constants for interview_generator.py
 from .generator_constants import generator_constants
 
@@ -387,6 +388,29 @@ class DAQuestion(DAObject):
                 content += "under: |\n" + indent_by(self.under_text, 2)
         elif self.type == 'code':
             content += "code: |\n" + indent_by(self.code, 2)
+        elif self.type == 'objects':
+            # An object should be a list of DAObjects with the following attributes:
+            # name, type, params [optional]
+            # params is going to be a list/iterable object of two or 3 item tuples or lists 
+            # of strings
+            # param[0] is the parameter name (argument to .using), param[1] is the value
+            # If the param has 3 parts, then param[1] will be treated as a literal rather than
+            # string value. string is default. Actual value of param[2] is reserved for future need
+            content += "objects:\n"
+            for object in self.objects:
+              content += "  - " + object.name + ':' + object.type
+              if hasattr(object, 'params'):
+                content += ".using("
+                for param in object.params:
+                  content += str(param[0]) + "="
+                  if len(param) > 2:
+                    # This might be an int value, other variable name, etc.
+                    content += str(param[1])
+                  else:
+                    # this is a normal string value and should get quoted.
+                    # use json.dumps() to properly quote strings. shouldn't come up
+                    content += json.dumps(str(param[1]))
+                                   
         elif self.type == 'interview order':
             # TODO: refactor this. Too much of it is assembly-line specific code
             # move into the interview YAML or a separate module/subclass

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1144,6 +1144,9 @@ def get_person_variables(fieldslist, people_vars=generator_constants.PEOPLE_VARS
   """
   people = set()
   for field in fieldslist:
+    # fields are tuples for PDF and strings for docx
+    if isinstance(field, tuple):
+      field = field[0]
     if remove_string_wrapper(field) in people_vars:
       people.add(field)
     if '[' in field or '.' in field:


### PR DESCRIPTION
This fixes #165 and #88 

It lays some groundwork for #163.

Putting in the PR now just so we can test this discrete code for now, but I'll keep on the same branch or a PR to this branch.