### PR TITLE
Phase 1 of Object Oriented Refactor: Fields

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -389,9 +389,8 @@ code: |
   field_data_types = ['text','integer','number','currency','date','email']
 
   temp_field_question = []
-  #TODO(brycew): DAField output for here
   for index, field in enumerate(fields.elements):
-    temp_field_question.extend(field.user_ask_yaml(index))
+    temp_field_question.extend(field.user_ask_about_field(index))
 
   field_question = temp_field_question
 ---
@@ -534,7 +533,6 @@ code: |
   # Something here should happen to eliminate duplicates before adding
   # to the logic list
   for index, field in enumerate(built_in_fields_used, start=len(questions) + 1):
-    # TODO(bryce): make OOP: don't refer to field.variable
     if index and index % screen_divisor == 0:
       progress += increment
       logic_list.append("set_progress(" + str(round(progress,2)) +")")    

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -294,7 +294,7 @@ code: |
       
       # This function determines what type of variable
       # we're dealing with
-      fill_in_field_attributes(new_field, pdf_field_tuple)    
+      new_field.fill_in_pdf_attributes(pdf_field_tuple)    
   else:
     # if this is a docx, fields are a list of strings, not a list of tuples
     for field in all_fields:
@@ -304,7 +304,7 @@ code: |
         new_field = signature_fields.appendObject()
       else:                
         new_field = fields.appendObject()
-      fill_in_docx_field_attributes(new_field, field)
+      new_field.fill_in_docx_field_attributes(field)
     
   get_all_fields = True
 ---
@@ -389,6 +389,7 @@ code: |
   field_data_types = ['text','integer','number','currency','date','email']
 
   temp_field_question = []
+  #TODO(brycew): DAField output for here
   for index, field in enumerate(fields.elements):
     if field.variable != field.docassemble_variable:
       temp_field_question.append({
@@ -542,6 +543,7 @@ code: |
       progress += increment
       logic_list.append("set_progress(" + str(round(progress,2)) +")")
     if question.type == 'question':
+      # TODO(bryce): make OOP: don't refer to question.type
       # Add the first field in every question to our logic tree
       # This can be customized to control the order of questions later      
       if hasattr(question, 'has_mandatory_field') and question.has_mandatory_field:
@@ -556,10 +558,11 @@ code: |
   # Something here should happen to eliminate duplicates before adding
   # to the logic list
   for index, field in enumerate(built_in_fields_used, start=len(questions) + 1):
+    # TODO(bryce): make OOP: don't refer to field.variable
     if index and index % screen_divisor == 0:
       progress += increment
       logic_list.append("set_progress(" + str(round(progress,2)) +")")    
-    logic_list.append(trigger_gather_string(map_names(field.variable)))
+    logic_list.append(field.trigger_gather)
   
   # Save a snapshot of interview answers. 
   # We only want a few anonymous variables

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -391,31 +391,7 @@ code: |
   temp_field_question = []
   #TODO(brycew): DAField output for here
   for index, field in enumerate(fields.elements):
-    if field.variable != field.docassemble_variable:
-      temp_field_question.append({
-        'note': '**' + field.variable + ' (will be renamed to ' + field.docassemble_variable + ')**'})
-    else:
-      temp_field_question.append({
-        'note': '**' + field.variable + '**'
-      })
-    temp_field_question.append({
-      'label': "On-screen prompt",
-      'field': 'fields[' + str(index) + '].label',
-      'default': field.variable_name_guess
-    })
-    temp_field_question.append({
-      'label': "Input style",
-      'field': 'fields[' + str(index) + '].field_type',
-      'choices': field_types,
-      'default': field.field_type_guess if hasattr(field, 'field_type_guess') else None
-    })
-    temp_field_question.append({
-      'label': "Datatype",
-      'field': 'fields[' + str(index) + '].field_data_type',
-      'choices': field_data_types,
-      'default': field.field_data_type_guess if hasattr(field, 'field_data_type_guess') else None,
-      'hide if': {'variable': 'fields[' + str(index) + '].field_type', 'is': 'yesno'}
-    })
+    temp_field_question.extend(field.user_ask_yaml(index))
 
   field_question = temp_field_question
 ---

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -164,7 +164,7 @@ class DAField(DAObject):
   """A field represents a Docassemble field/variable. I.e., a single piece of input we are gathering from the user."""
   def init(self, **kwargs):
     return super().init(**kwargs)
-  # TODO(brycew): add a ".attachment_block()", ".review_block()", and ".trigger_block()" to each
+
   def fill_in_docx_attributes(self, new_field_name,
                               reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP):
     """The DAField class expects a few attributes to be filled in.
@@ -254,19 +254,18 @@ class DAField(DAObject):
       content += "  - no label: {}\n".format(field_name_to_use)
 
     # Use all of these fields plainly. No restrictions/validation yet
-    if self.field_type in ['yesno', 'yesnomaybe', 'file'] or \
-        self.field_data_type in  ['number', 'date']: 
+    if self.field_type in ['yesno', 'yesnomaybe', 'file']:
       content += "    datatype: {}\n".format(self.field_type)
     elif self.field_type == 'area':
       content += "    input type: area\n"
       content += self._maxlength_str() + '\n'
-    elif self.field_data_type in ['integer', 'currency', 'email', 'range']:
+    elif self.field_data_type in ['integer', 'currency', 'email', 'range', 'number', 'date']:
       content += "    datatype: {}\n".format(self.field_data_type)
       if self.field_data_type in ['integer', 'currency']:
         content += "    min: 0\n"
       elif self.field_data_type == 'email':
         content += self._maxlength_str() + '\n'
-      else:  # range
+      elif self.field_data_type == 'range':
         content += "    min: {}\n".format(self.range_min)
         content += "    max: {}\n".format(self.range_max)
         content += "    step: {}\n".format(self.range_step)
@@ -315,10 +314,9 @@ class DAField(DAObject):
     # To avoid duplicate key error
     field_varname = varname(self.variable)
     content = '      - "{}": '.format(self.variable)
-    if hasattr(self, 'field_data_type'):
-      if self.field_data_type == 'date':
+    if hasattr(self, 'field_data_type') and self.field_data_type == 'date':
         content += '${ ' + field_varname.format() + ' }\n'
-      elif self.field_data_type == 'currency':
+    elif hasattr(self, 'field_data_type') and self.field_data_type == 'currency':
         content += '${ currency(' + field_varname + ') }\n'
     elif self.field_type_guess == 'signature': 
       comment = "      # It's a signature: test which file version this is; leave empty unless it's the final version)\n"
@@ -328,7 +326,7 @@ class DAField(DAObject):
     log('attachment_yaml for {}: {}'.format(self.variable, content), 'console')
     return content
 
-  def user_ask_yaml(self, index):
+  def user_ask_about_field(self, index):
     field_questions = []
     if self.variable != self.docassemble_variable:
       field_questions.append({

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -22,7 +22,7 @@ from .generator_constants import generator_constants
 
 TypeType = type(type(None))
 
-__all__ = ['Playground', 'PlaygroundSection', 'indent_by', 'varname', 'DAField', 'DAFieldList', 'DAQuestion', 'DAInterview', 'DAAttachmentList', 'DAAttachment', 'to_yaml_file', 'base_name', 'to_package_name', 'oneline', 'DAQuestionList', 'map_names', 'trigger_gather_string', 'is_reserved_label', 'fill_in_field_attributes', 'attachment_download_html', 'get_fields','fill_in_docx_field_attributes','is_reserved_docx_label','get_character_limit']
+__all__ = ['Playground', 'PlaygroundSection', 'indent_by', 'varname', 'DAField', 'DAFieldList', 'DAQuestion', 'DAInterview', 'DAAttachmentList', 'DAAttachment', 'to_yaml_file', 'base_name', 'to_package_name', 'oneline', 'DAQuestionList', 'map_names', 'trigger_gather_string', 'is_reserved_label', 'attachment_download_html', 'get_fields','is_reserved_docx_label','get_character_limit']
 
 always_defined = set(["False", "None", "True", "dict", "i", "list", "menu_items", "multi_user", "role", "role_event", "role_needed", "speak_text", "track_location", "url_args", "x", "nav", "PY2", "string_types"])
 replace_square_brackets = re.compile(r'\\\[ *([^\\]+)\\\]')
@@ -64,71 +64,6 @@ def get_character_limit(pdf_field_tuple, char_width=6, row_height=12):
 
   max_chars = num_rows * num_cols
   return max_chars
-
-def fill_in_docx_field_attributes(new_field, new_field_name,
-                                  reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP):
-    """The DAField class expects a few attributes to be filled in.
-    In a future version of this, maybe we can use context to identify
-    true/false variables. For now, we can only use the name.
-    We have a lot less info than for PDF fields.
-    """
-    new_field.variable = new_field_name
-    new_field.docassemble_variable = new_field_name  # no transformation changes
-    new_field.trigger_gather = trigger_gather_string(new_field.docassemble_variable)
-    new_field.has_label = True
-
-    # this will let us edit the name field if document just refers to
-    # the whole object
-    if new_field_name in reserved_pluralizers_map.values():
-        new_field.edit_attribute = new_field_name + '[0].name.first'
-    if new_field_name in [label + '[0]' for label in reserved_pluralizers_map.values()]:
-        new_field.edit_attribute = new_field_name + '.name.first'
-
-    # variable_name_guess is the placeholder label for the field
-    variable_name_guess = new_field.variable.replace('_', ' ').capitalize()
-    if new_field.variable.endswith('_date'):
-        new_field.field_type_guess = 'text'
-        new_field.field_data_type_guess = 'date'
-        new_field.variable_name_guess = 'Date of ' + new_field.variable[:-5].replace('_', ' ')
-    elif new_field.variable.endswith('.signature'):
-        new_field.field_type_guess = "signature"
-        new_field.field_data_type_guess = None
-        new_field.variable_name_guess = variable_name_guess
-    else:
-        new_field.field_type_guess = 'text'
-        new_field.field_data_type_guess = 'text'
-        new_field.variable_name_guess = variable_name_guess
-
-
-def fill_in_field_attributes(new_field, pdf_field_tuple):
-    # Let's guess the type of each field from the name / info from PDF
-    new_field.variable = varname(pdf_field_tuple[0])
-    new_field.docassemble_variable = map_names(pdf_field_tuple[0])  # TODO: wrap in varname
-    new_field.trigger_gather = trigger_gather_string(new_field.docassemble_variable)
-
-    variable_name_guess = new_field.variable.replace('_', ' ').capitalize()
-    new_field.has_label = True
-    if new_field.variable.endswith('_date'):
-        new_field.field_type_guess = 'text'
-        new_field.field_data_type_guess = 'date'
-        new_field.variable_name_guess = 'Date of ' + new_field.variable[:-5].replace('_', ' ')
-    elif new_field.variable.endswith('_yes') or new_field.variable.endswith('_no'):
-        new_field.field_type_guess = 'yesno'
-        new_field.field_data_type_guess = None
-        new_field.variable_name_guess = new_field.variable[:-3].replace('_', ' ').capitalize() if new_field.variable.endswith('_no') else new_field.variable[:-4].replace('_',' ').capitalize()
-    elif pdf_field_tuple[4] == '/Btn':
-        new_field.field_type_guess = 'yesno'
-        new_field.field_data_type_guess = None
-        new_field.variable_name_guess = variable_name_guess
-    elif pdf_field_tuple[4] == "/Sig":
-        new_field.field_type_guess = "signature"
-        new_field.field_data_type_guess = None
-        new_field.variable_name_guess = variable_name_guess
-    else:
-        new_field.field_type_guess = 'text'
-        new_field.field_data_type_guess = 'text'
-        new_field.variable_name_guess = variable_name_guess
-    new_field.maxlength = get_character_limit(pdf_field_tuple)
 
 class DAAttachment(DAObject):
     """This class represents the attachment block we will create in the final output YAML"""
@@ -225,9 +160,171 @@ class DAInterview(DAObject):
         return "---\n".join(output)
 
 class DAField(DAObject):
-    """A field represents a Docassemble field/variable. I.e., a single piece of input we are gathering from the user."""
-    def init(self, **kwargs):
-        return super().init(**kwargs)
+  """A field represents a Docassemble field/variable. I.e., a single piece of input we are gathering from the user."""
+  def init(self, **kwargs):
+    return super().init(**kwargs)
+  # TODO(brycew): add a ".attachment_block()", ".review_block()", and ".trigger_block()" to each
+  def fill_in_docx_attributes(self, new_field_name,
+                              reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP):
+    """The DAField class expects a few attributes to be filled in.
+    In a future version of this, maybe we can use context to identify
+    true/false variables. For now, we can only use the name.
+    We have a lot less info than for PDF fields.
+    """
+    self.variable = new_field_name
+    self.docassemble_variable = new_field_name  # no transformation changes
+    self.trigger_gather = trigger_gather_string(self.docassemble_variable)
+    self.has_label = True
+
+    # this will let us edit the name field if document just refers to
+    # the whole object
+    if new_field_name in reserved_pluralizers_map.values():
+      self.edit_attribute = new_field_name + '[0].name.first'
+    if new_field_name in [label + '[0]' for label in reserved_pluralizers_map.values()]:
+      self.edit_attribute = new_field_name + '.name.first'
+
+    # variable_name_guess is the placeholder label for the field
+    variable_name_guess = self.variable.replace('_', ' ').capitalize()
+    if self.variable.endswith('_date'):
+      self.field_type_guess = 'text'
+      self.field_data_type_guess = 'date'
+      self.variable_name_guess = 'Date of ' + self.variable[:-5].replace('_', ' ')
+    elif self.variable.endswith('.signature'):
+      self.field_type_guess = "signature"
+      self.field_data_type_guess = None
+      self.variable_name_guess = variable_name_guess
+    else:
+      self.field_type_guess = 'text'
+      self.field_data_type_guess = 'text'
+      self.variable_name_guess = variable_name_guess
+
+  def fill_in_pdf_attributes(self, pdf_field_tuple):
+    """Let's guess the type of each field from the name / info from PDF"""
+    self.variable = varname(pdf_field_tuple[0])
+    self.docassemble_variable = map_names(pdf_field_tuple[0])  # TODO: wrap in varname
+    self.trigger_gather = trigger_gather_string(self.docassemble_variable)
+
+    variable_name_guess = self.variable.replace('_', ' ').capitalize()
+    self.has_label = True
+    if self.variable.endswith('_date'):
+        self.field_type_guess = 'text'
+        self.field_data_type_guess = 'date'
+        self.variable_name_guess = 'Date of ' + self.variable[:-5].replace('_', ' ')
+    elif self.variable.endswith('_yes') or self.variable.endswith('_no'):
+        self.field_type_guess = 'yesno'
+        self.field_data_type_guess = None
+        self.variable_name_guess = self.variable[:-3] if self.variable.endswith('_no') else self.variable[:-4]
+        self.variable_name_guess = self.variable_name_guess.replace('_', ' ').capitalize()
+    elif pdf_field_tuple[4] == '/Btn':
+        self.field_type_guess = 'yesno'
+        self.field_data_type_guess = None
+        self.variable_name_guess = variable_name_guess
+    elif pdf_field_tuple[4] == "/Sig":
+        self.field_type_guess = "signature"
+        self.field_data_type_guess = None
+        self.variable_name_guess = variable_name_guess
+    else:
+        self.field_type_guess = 'text'
+        self.field_data_type_guess = 'text'
+        self.variable_name_guess = variable_name_guess
+    self.maxlength = get_character_limit(pdf_field_tuple)
+
+  def get_single_field_screen(self, document_type):
+    field_name_to_use = map_names(self.variable, document_type=document_type)
+    if self.field_type == 'yesno':
+      return "yesno: {}\n".format(field_name_to_use), True
+    elif self.field_type == 'yesnomaybe':
+      return "yesnomaybe: {}\n".format(field_name_to_use), True
+    else:
+      return "", False
+
+  def get_maxlength_str(self):
+    if hasattr(self, 'maxlength') and self.maxlength:
+      return "    maxlength: {}".format(self.maxlength)
+    else:
+      return ""
+
+  def get_field_entry_yaml(self, document_type):
+    field_name_to_use = map_names(self.variable, document_type=document_type)
+    content = ""
+    if self.has_label:
+      content += "  - {}: {}\n".format(repr_str(self.label), field_name_to_use)
+    else:
+      content += "  - no label: {}\n".format(field_name_to_use)
+
+    # Use all of these fields plainly. No restrictions/validation yet
+    if self.field_type in ['yesno', 'yesnomaybe', 'file'] or \
+        self.field_data_type in  ['number', 'date']: 
+      content += "    datatype: {}".format(self.field_type)
+    elif self.field_type == 'area':
+      content += "    input type: area\n"
+      content += self.get_maxlength_str()
+    elif self.field_data_type in ['integer', 'currency', 'email', 'range']:
+      content += "    datatype: {}".format(self.field_data_type)
+      if self.field_data_type in ['integer', 'currency']:
+        content += "    min: 0\n"
+      elif self.field_data_type == 'email':
+        content += self.get_maxlength_str()
+      else:  # range
+        content += "    min: {}\n".format(self.range_min)
+        content += "    max: {}\n".format(self.range_max)
+        content += "    step: {}\n".format(self.range_step)
+    else:  # a standard text field
+      content += self.get_maxlength_str()
+
+    return content
+
+  def get_review_screen_yaml(self, document_type, field_names):
+    field_name_to_use = unmap(map_names(self.variable, document_type=document_type))
+    if field_name_to_use in field_names:
+      return ""
+
+    content = ""
+    if hasattr(self, 'edit_attribute'):
+      content += '  - Edit: ' + self.edit_attribute + "\n"
+    else:
+      content += '  - Edit: ' + field_name_to_use + "\n"
+    content += '    button: |\n'
+    edit_display_name = self.label if hasattr(self,'label') else field_name_to_use
+    content += indent_by(docassemble.base.functions.bold(edit_display_name) + ": ", 6)
+    if hasattr(self, 'field_type'):
+      if self.field_type in ['yesno', 'yesnomaybe']:
+        content += indent_by('${ word(yesno(' + field_name_to_use + ')) }', 6)
+      elif self.field_data_type in ['integer', 'number','range']:
+        content += indent_by('${ ' + field_name_to_use + ' }', 6)
+      elif self.field_type == 'area':
+        content += indent_by('> ${ single_paragraph(' + field_name_to_use + ') }', 6)
+      elif self.field_type == 'file':
+        content += "      \n"
+        content += indent_by('${ ' + field_name_to_use + ' }', 6)
+      elif self.field_data_type == 'currency':
+        content += indent_by('${ currency(' + field_name_to_use + ') }', 6)
+      elif self.field_data_type == 'date':
+        content += indent_by('${ ' + field_name_to_use + '.format() }', 6)
+      # elif field.field_data_type == 'email':
+      else:
+        content += indent_by('${ ' + field_name_to_use + ' }', 6)
+    else:
+      content += indent_by('${ ' + field_name_to_use + ' }', 6)
+    field_names.add(field_name_to_use)
+
+  def get_attachment_yaml(self):
+    # Lets use the list-style, not dictionary style fields statement
+    # To avoid duplicate key error
+    field_varname = varname(self.variable)
+    content = indent_by('- "{}": '.format(self.variable), 6)
+    if hasattr(self, 'field_data_type'):
+      if self.field_data_type == 'date':
+        content += '${ ' + field_varname.format() + ' }\n'
+      elif self.field_data_type == 'currency':
+        content += '${ currency(' + field_varname + ' ) }\n'
+    elif self.field_type_guess == 'signature': 
+      comment = "      # It's a signature: test which file version this is; leave empty unless it's the final version)\n"
+      content = comment + content + '${ ' + map_names(field_varname) + " if i == 'final' else '' }\n"
+    else:
+      content += '${ ' + map_names(field_varname) + ' }\n'
+    return content
+
 
 class DAFieldList(DAList):
     """A DAFieldList contains multiple DAFields."""
@@ -239,6 +336,7 @@ class DAFieldList(DAList):
     def __str__(self):
         """I don't think this method has a real function in our code base. Perhaps debugging."""
         return docassemble.base.functions.comma_and_list(map(lambda x: '`' + x.variable + '`', self.elements))
+
 
 class DAQuestion(DAObject):
     """This class represents a "question" in the generated YAML file. TODO: move
@@ -253,6 +351,7 @@ class DAQuestion(DAObject):
         self.templates_used = set()
         self.static_files_used = set()
         return super().init(**kwargs)
+
     def source(self, follow_additional_fields=True, document_type="pdf"):
         """This method outputs the YAML code representing a single "question" in the interview."""
         content = ''
@@ -276,15 +375,10 @@ class DAQuestion(DAObject):
             if self.subquestion_text != "":
                 content += "subquestion: |\n" + indent_by(self.subquestion_text, 2)
             if len(self.field_list) == 1:
-                field_name_to_use = map_names(self.field_list[0].variable, document_type=document_type)
-                if self.field_list[0].field_type == 'yesno':
-                    content += "yesno: " + field_name_to_use + "\n"
-                    done_with_content = True
-                elif self.field_list[0].field_type == 'yesnomaybe':
-                    content += "yesnomaybe: " + field_name_to_use + "\n"
-                    done_with_content = True
+                new_content, done_with_content = self.field_list[0].get_single_field_screen(document_type)
+                content += new_content
             if self.field_list[0].field_type == 'end_attachment':
-                if hasattr(self, 'interview_label'): # this tells us its the ending screen
+                if hasattr(self, 'interview_label'):  # this tells us its the ending screen
                   # content += "buttons:\n  - Exit: exit\n  - Restart: restart\n" # we don't want people to erase their session
                   content += "need: " + self.interview_label + "\n"
                   # TODO: insert the email code
@@ -292,7 +386,7 @@ class DAQuestion(DAObject):
                 #if (isinstance(self, DAAttachmentList) and self.attachments.gathered and len(self.attachments)) or (len(self.attachments)):
                 # attachments is no longer always a DAList
                 # TODO / FUTURE we could let this handle multiple forms at once
-                for attachment in self.attachments: # We will only have ONE attachment
+                for attachment in self.attachments:  # We will only have ONE attachment
                     # TODO: if we really use multiple attachments, we need to change this
                     # So there is a unique variable name
                     content += "---\n"
@@ -320,18 +414,7 @@ class DAQuestion(DAObject):
                         # for field, default, pageno, rect, field_type in attachment.fields:
                         # Switching to using a DAField, rather than a raw PDF field
                         for field in attachment.fields:
-                            # Lets use the list-style, not dictionary style fields statement
-                            # To avoid duplicate key error
-                            if hasattr(field, 'field_data_type') and field.field_data_type == 'date':
-                              content += '      - "' + field.variable + '": ${ ' + varname(field.variable).format() + " }\n"
-                            elif hasattr(field, 'field_data_type') and field.field_data_type == 'currency':
-                              content += '      - "' + field.variable + '": ${ currency(' + varname(field.variable) + " ) }\n"
-                            elif map_names(varname(field.variable)).endswith('.signature'):
-                              content += "      # If it is a signature, test which file version we're expecting. leave it empty unless it's the final attachment version\n"
-                              content += '      - "' + field.variable +'": ${ ' + map_names(varname(field.variable)) + " if i == 'final' else '' }\n"
-                            else:
-                              # content += '      "' + field.variable + '": ${ ' + process_variable_name(varname(field.variable)) + " }\n"
-                              content += '      - "' + field.variable + '": ${ ' + map_names(varname(field.variable)) + " }\n"
+                          content += field.get_attachment_yaml()
                     elif attachment.type == 'docx':
                         content += "    docx template file: " + oneline(attachment.docx_filename) + "\n"
                         self.templates_used.add(attachment.docx_filename)
@@ -339,43 +422,7 @@ class DAQuestion(DAObject):
             if not done_with_content:
                 content += "fields:\n"
                 for field in self.field_list:
-                    field_name_to_use = map_names(field.variable, document_type=document_type)
-                    if field.has_label:
-                        content += "  - " + repr_str(field.label) + ": " + field_name_to_use + "\n"
-                    else:
-                        content += "  - no label: " + field_name_to_use + "\n"
-                    if field.field_type == 'yesno':
-                        content += "    datatype: yesno\n"
-                    elif field.field_type == 'yesnomaybe':
-                        content += "    datatype: yesnomaybe\n"
-                    elif field.field_type == 'area':
-                        content += "    input type: area\n"
-                        if hasattr(field, 'maxlength') and field.maxlength:
-                          content += "    maxlength: " + str(field.maxlength) + "\n"
-                    elif field.field_type == 'file':
-                        content += "    datatype: file\n"
-                    elif field.field_data_type == 'integer':
-                        content += "    datatype: integer\n"
-                        content += "    min: 0\n"
-                    elif field.field_data_type == 'number':
-                        content += "    datatype: number\n"
-                    elif field.field_data_type == 'currency':
-                        content += "    datatype: currency\n"
-                        content += "    min: 0\n"
-                    elif field.field_data_type == 'date':
-                        content += "    datatype: date\n"
-                    elif field.field_data_type == 'email':
-                        content += "    datatype: email\n"
-                        if hasattr(field, 'maxlength') and field.maxlength:
-                          content += "    maxlength: " + str(field.maxlength) + "\n"
-                    elif field.field_data_type == 'range':
-                        content += "    datatype: range\n"
-                        content += "    min: " + field.range_min + "\n"
-                        content += "    max: " + field.range_max + "\n"
-                        content += "    step: " + field.range_step + "\n"
-                    else: # a standard text field
-                        if hasattr(field, 'maxlength') and field.maxlength:
-                          content += "    maxlength: " + str(field.maxlength) + "\n"
+                    content += field.get_field_entry_yaml(document_type)
 
         elif self.type == 'signature':
             content += "signature: " + varname(self.field_list[0].variable) + "\n"
@@ -396,10 +443,11 @@ class DAQuestion(DAObject):
             signatures = set()
             added_field_names = set()
             for field in self.logic_list:
-              if field.endswith('.signature'): # save the signatures for the end
+              if field.endswith('.signature'):  # save the signatures for the end
                 signatures.add(field)
               elif not field in added_field_names:
-                content += "  " + field + "\n" # We built this logic list by collecting the first field on each screen
+                # We built this logic list by collecting the first field on each screen
+                content += "  " + field + "\n"
               added_field_names.add(field)
             content += "  " + self.interview_label + '_preview_question # Pre-canned preview screen\n'
             content += "  basic_questions_signature_flow\n"
@@ -443,7 +491,8 @@ class DAQuestion(DAObject):
             if hasattr(self, 'comment'):
                 content += 'comment: |\n'
                 content += indent_by(self.comment, 2)
-            content += "mandatory: True\n" # We need this block to run every time to build our metadata variable
+            # We need this block to run every time to build our metadata variable
+            content += "mandatory: True\n"
             content += "code: |\n"
             content += "  interview_metadata # make sure we initialize the object\n"
             content += "  if not defined(\"interview_metadata['"+ self.interview_label +  "']\"):\n"
@@ -485,11 +534,11 @@ class DAQuestion(DAObject):
             content += "id: " + self.id + "\n"
           else:
             content += "id: " + oneline(self.question_text) + "\n"
-          content += 'continue button field: '+ self.continue_button_field + "\n"
+          content += 'continue button field: ' + self.continue_button_field + "\n"
           content += "question: |\n"
           content += indent_by(self.question_text, 2)
           content += "subquestion: |\n"
-          content += indent_by(self.subquestion_text,2)
+          content += indent_by(self.subquestion_text, 2)
         elif self.type == "review":
           if hasattr(self, 'id') and self.id:
               content += "id: " + self.id + "\n"
@@ -500,39 +549,11 @@ class DAQuestion(DAObject):
           content += "question: |\n"
           content += indent_by(self.question_text, 2)
           content += "subquestion: |\n"
-          content += indent_by(self.subquestion_text,2)
+          content += indent_by(self.subquestion_text, 2)
           content += "review: \n"
           field_names = set()
           for field in self.field_list:
-              field_name_to_use = remove_string_wrapper(map_names(field.variable, document_type=document_type))
-              if field_name_to_use not in field_names:
-                if hasattr(field, 'edit_attribute'):
-                    content += '  - Edit: ' + field.edit_attribute + "\n"
-                else:
-                    content += '  - Edit: ' + field_name_to_use + "\n"
-                content += '    button: |' + "\n"
-                edit_display_name = field.label if hasattr(field,'label') else field_name_to_use
-                content += indent_by(docassemble.base.functions.bold(edit_display_name) + ": ", 6)
-                if hasattr(field, 'field_type'):
-                    if field.field_type in ['yesno', 'yesnomaybe']:
-                        content += indent_by('${ word(yesno(' + field_name_to_use + ')) }', 6)
-                    elif field.field_data_type in ['integer', 'number','range']:
-                        content += indent_by('${ ' + field_name_to_use + ' }', 6)
-                    elif field.field_type == 'area':
-                        content += indent_by('> ${ single_paragraph(' + field_name_to_use + ') }', 6)
-                    elif field.field_type == 'file':
-                        content += "      \n"
-                        content += indent_by('${ ' + field_name_to_use + ' }', 6)
-                    elif field.field_data_type == 'currency':
-                        content += indent_by('${ currency(' + field_name_to_use + ') }', 6)
-                    elif field.field_data_type == 'date':
-                        content += indent_by('${ ' + field_name_to_use + '.format() }', 6)
-                    # elif field.field_data_type == 'email':
-                    else:
-                        content += indent_by('${ ' + field_name_to_use + ' }', 6)
-                else:
-                    content += indent_by('${ ' + field_name_to_use + ' }', 6)
-                field_names.add(field_name_to_use)
+              content += field.get_review_screen_yaml(document_type, field_names)
         return content
 
 class DAQuestionList(DAList):
@@ -765,7 +786,7 @@ class Playground(PlaygroundSection):
         return dict(names_used=names_used, undefined_names=undefined_names, fields_used=fields_used, all_names=all_names, all_names_reduced=all_names_reduced)
 
 def fix_id(string):
-    return re.sub('[\W_]+', ' ', string).strip()
+    return re.sub(r'[\W_]+', ' ', string).strip()
 
 def fix_variable_name(match):
     var_name = match.group(1)
@@ -981,7 +1002,7 @@ def trigger_gather_string(docassemble_var,
     return docassemble_var + GATHER_CALL
 
   # Everything before the first period and everything from the first period to the end
-  var_with_attribute = remove_string_wrapper(docassemble_var)
+  var_with_attribute = unmap(docassemble_var)
   var_parts = re.findall(r'([^.]+)(\.[^.]*)?', var_with_attribute)
 
   # test for existence (empty strings result in a tuple)
@@ -1006,7 +1027,7 @@ def is_reserved_docx_label(label, docx_only_suffixes=generator_constants.DOCX_ON
                            reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP,
                            reserved_suffixes_map=generator_constants.RESERVED_SUFFIXES_MAP):
     '''Given a string, will return whether the string matches
-       reserved variable names. `label` must be a string.'''
+    reserved variable names. `label` must be a string.'''
     if label in reserved_whole_words:
         return True
 
@@ -1084,13 +1105,7 @@ def is_reserved_label(label, reserved_whole_words = generator_constants.RESERVED
 def remove_multiple_appearance_indicator(label):
     return re.sub(r'_{2,}\d+', '', label)
 
-def get_stringifiable_version(label):
-    return 'str(' + label + ')'
-
-def remove_string_wrapper(label, unmap_suffixes = generator_constants.UNMAP_SUFFIXES):
-    if label.startswith('str('):
-        return label[4:-1]
-
+def unmap(label, unmap_suffixes=generator_constants.UNMAP_SUFFIXES):
     # map address() etc backwards
     for suffix in unmap_suffixes:
         if label.endswith(suffix):
@@ -1128,7 +1143,7 @@ def is_person(field_name, people_vars=generator_constants.PEOPLE_VARS):
   Check if the field name appears to represent a person
   """
   # Is it exactly a person variable: e.g., `users`
-  if remove_string_wrapper(field_name) in people_vars:
+  if field_name in people_vars:
     return True
   if '[' in field_name or '.' in field_name:
     match_with_brackets_or_attribute = r"(\D\w*)((\[.*)|(\..*))"

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -256,22 +256,22 @@ class DAField(DAObject):
     # Use all of these fields plainly. No restrictions/validation yet
     if self.field_type in ['yesno', 'yesnomaybe', 'file'] or \
         self.field_data_type in  ['number', 'date']: 
-      content += "    datatype: {}".format(self.field_type)
+      content += "    datatype: {}\n".format(self.field_type)
     elif self.field_type == 'area':
       content += "    input type: area\n"
-      content += self._maxlength_str()
+      content += self._maxlength_str() + '\n'
     elif self.field_data_type in ['integer', 'currency', 'email', 'range']:
-      content += "    datatype: {}".format(self.field_data_type)
+      content += "    datatype: {}\n".format(self.field_data_type)
       if self.field_data_type in ['integer', 'currency']:
         content += "    min: 0\n"
       elif self.field_data_type == 'email':
-        content += self._maxlength_str()
+        content += self._maxlength_str() + '\n'
       else:  # range
         content += "    min: {}\n".format(self.range_min)
         content += "    max: {}\n".format(self.range_max)
         content += "    step: {}\n".format(self.range_step)
     else:  # a standard text field
-      content += self._maxlength_str()
+      content += self._maxlength_str() + '\n'
 
     return content
 
@@ -314,7 +314,7 @@ class DAField(DAObject):
     # Lets use the list-style, not dictionary style fields statement
     # To avoid duplicate key error
     field_varname = varname(self.variable)
-    content = indent_by('- "{}": '.format(self.variable), 6)
+    content = '      - "{}": '.format(self.variable)
     if hasattr(self, 'field_data_type'):
       if self.field_data_type == 'date':
         content += '${ ' + field_varname.format() + ' }\n'
@@ -325,6 +325,7 @@ class DAField(DAObject):
       content = comment + content + '${ ' + map_names(field_varname) + " if i == 'final' else '' }\n"
     else:
       content += '${ ' + map_names(field_varname) + ' }\n'
+    log('attachment_yaml for {}: {}'.format(self.variable, content), 'console')
     return content
 
   def user_ask_yaml(self, index):
@@ -356,6 +357,7 @@ class DAField(DAObject):
       'hide if': {'variable': 'fields[' + str(index) + '].field_type', 'is': 'yesno'}
     })
     return field_questions
+
 
 class DAFieldList(DAList):
     """A DAFieldList contains multiple DAFields."""

--- a/docassemble/assemblylinewizard/test_fill_in_field_attributes.py
+++ b/docassemble/assemblylinewizard/test_fill_in_field_attributes.py
@@ -61,7 +61,7 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
 
     def test_sig_field(self):
         pdf_field_tuple = ('signature', '', 0, [10, 10, 100, 30], '/Sig')
-        new_field = MagicMock(wraps=new_field)
+        new_field = MagicMock(wraps=DAField)
         new_field.fill_in_pdf_attributes(pdf_field_tuple)
         self.assertEqual(new_field.variable, 'signature')
         self.assertEqual(new_field.docassemble_variable, 'signature')

--- a/docassemble/assemblylinewizard/test_fill_in_field_attributes.py
+++ b/docassemble/assemblylinewizard/test_fill_in_field_attributes.py
@@ -1,13 +1,13 @@
 import unittest
 from unittest.mock import MagicMock
-from interview_generator import fill_in_field_attributes
+from interview_generator import DAField
 
-class test_fill_in_field_attributes(unittest.TestCase):
+class test_fill_in_pdf_attributes(unittest.TestCase):
 
     def test_simple_pdf_field(self):
         pdf_field_tuple = ('field_name', 'default text', 0, [10, 10, 100, 30], '/Tx')
-        new_field = MagicMock()
-        fill_in_field_attributes(new_field, pdf_field_tuple)
+        new_field = MagicMock(wraps=DAField)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple)
         self.assertEqual(new_field.variable, 'field_name')
         self.assertEqual(new_field.docassemble_variable, 'field_name')
         self.assertEqual(new_field.has_label, True)
@@ -17,8 +17,8 @@ class test_fill_in_field_attributes(unittest.TestCase):
 
     def test_date_field(self):
         pdf_field_tuple = ('birth_date', '', 0, [10, 10, 100, 30], '/Tx')
-        new_field = MagicMock()
-        fill_in_field_attributes(new_field, pdf_field_tuple)
+        new_field = MagicMock(wraps=DAField)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple)
         self.assertEqual(new_field.variable, 'birth_date')
         self.assertEqual(new_field.docassemble_variable, 'birth_date')
         self.assertEqual(new_field.has_label, True)
@@ -28,8 +28,8 @@ class test_fill_in_field_attributes(unittest.TestCase):
 
     def test_yes_text_field(self):
         pdf_field_tuple = ('has_ssn_yes', '', 0, [10, 10, 100, 30], '/Tx')
-        new_field = MagicMock()
-        fill_in_field_attributes(new_field, pdf_field_tuple)
+        new_field = MagicMock(wraps=DAField)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple)
         self.assertEqual(new_field.variable, 'has_ssn_yes')
         self.assertEqual(new_field.docassemble_variable, 'has_ssn_yes')
         self.assertEqual(new_field.has_label, True)
@@ -39,8 +39,8 @@ class test_fill_in_field_attributes(unittest.TestCase):
 
     def test_no_text_field(self):
         pdf_field_tuple = ('has_ssn_no', '', 0, [10, 10, 100, 30], '/Tx')
-        new_field = MagicMock()
-        fill_in_field_attributes(new_field, pdf_field_tuple)
+        new_field = MagicMock(wraps=DAField)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple)
         self.assertEqual(new_field.variable, 'has_ssn_no')
         self.assertEqual(new_field.docassemble_variable, 'has_ssn_no')
         self.assertEqual(new_field.has_label, True)
@@ -50,8 +50,8 @@ class test_fill_in_field_attributes(unittest.TestCase):
 
     def test_yesno_btn_field(self):
         pdf_field_tuple = ('has_ssn', '', 0, [10, 10, 100, 30], '/Btn')
-        new_field = MagicMock()
-        fill_in_field_attributes(new_field, pdf_field_tuple)
+        new_field = MagicMock(wraps=DAField)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple)
         self.assertEqual(new_field.variable, 'has_ssn')
         self.assertEqual(new_field.docassemble_variable, 'has_ssn')
         self.assertEqual(new_field.has_label, True)
@@ -61,8 +61,8 @@ class test_fill_in_field_attributes(unittest.TestCase):
 
     def test_sig_field(self):
         pdf_field_tuple = ('signature', '', 0, [10, 10, 100, 30], '/Sig')
-        new_field = MagicMock()
-        fill_in_field_attributes(new_field, pdf_field_tuple)
+        new_field = MagicMock(wraps=new_field)
+        new_field.fill_in_pdf_attributes(pdf_field_tuple)
         self.assertEqual(new_field.variable, 'signature')
         self.assertEqual(new_field.docassemble_variable, 'signature')
         self.assertEqual(new_field.has_label, True)


### PR DESCRIPTION
TL;DR: interviews before and after this PR should be the same, let me know if I should include more refactors in this PR. 

Starts work on #137, which even though it's a Future milestone, will make working on #127/#95 (yes no combination), #59, and #38 easier, as those all have to do with the review screen versions of fields. 

Before this PR, the `interview_generator` carried around a list of different fields, and when it needed to generate review block yaml, attachment block yaml, or field attribute yaml, it iterated through the fields and generated the yaml needed. This works, but is a bit confusing to navigate, results in a very large `DAQuestion.source` [method](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/blob/f457335d16ed33743f45468f9ee49966d5f02d3d/docassemble/assemblylinewizard/interview_generator.py#L256) and leaves field member usage scattered throughout the module and interview.

Now, any access to a field's internal attribute (besides `.trigger_gather` in the interview order block (line 539, assembly_line.yml)), is through the DAField methods, `field_entry_yaml`, `review_yaml`, `attachment_yaml`, and `user_ask_about_field`. The code in `DAQuestion` and regarding `field_data_type`, and `field_type` is still a bit messy though.

I'm explicitly trying to to keep the keep the external functionality the same for this PR same. So running a form through the wizard before and after this PR, making the same choices, should result in **same output** (there is one comment that I clarified). Example below:

```bash
$ diff civil_docketing_statement_new.yml  civil_docketing_statement_old.yml 
231c231
<       # It's a signature: test which file version this is; leave empty unless it's the final version)
---
>       # If it is a signature, test which file version we're expecting. leave it empty unless it's the final attachment version
238c238
<       # It's a signature: test which file version this is; leave empty unless it's the final version)
---
>       # If it is a signature, test which file version we're expecting. leave it empty unless it's the final attachment version
```

I arbitrarily decided to stop refactoring here, as it got a little hairy trying to make sure the output was the same. I'm open to any more improvements I missed here, feel free to point them out. 