### PR TITLE
Only show user "field type", not input and data types + Format numbers

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -385,9 +385,6 @@ code: |
   # Create code for the question that we use to label
   # each field.
   
-  field_types = ['yesno','text','area']  
-  field_data_types = ['text','integer','number','currency','date','email']
-
   temp_field_question = []
   for index, field in enumerate(fields.elements):
     temp_field_question.extend(field.user_ask_about_field(index))

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -187,16 +187,13 @@ class DAField(DAObject):
     # variable_name_guess is the placeholder label for the field
     variable_name_guess = self.variable.replace('_', ' ').capitalize()
     if self.variable.endswith('_date'):
-      self.field_type_guess = 'text'
-      self.field_data_type_guess = 'date'
+      self.field_type_guess = 'date'
       self.variable_name_guess = 'Date of ' + self.variable[:-5].replace('_', ' ')
     elif self.variable.endswith('.signature'):
       self.field_type_guess = "signature"
-      self.field_data_type_guess = None
       self.variable_name_guess = variable_name_guess
     else:
       self.field_type_guess = 'text'
-      self.field_data_type_guess = 'text'
       self.variable_name_guess = variable_name_guess
 
   def fill_in_pdf_attributes(self, pdf_field_tuple):
@@ -208,25 +205,20 @@ class DAField(DAObject):
     variable_name_guess = self.variable.replace('_', ' ').capitalize()
     self.has_label = True
     if self.variable.endswith('_date'):
-        self.field_type_guess = 'text'
-        self.field_data_type_guess = 'date'
+        self.field_type_guess = 'date'
         self.variable_name_guess = 'Date of ' + self.variable[:-5].replace('_', ' ')
     elif self.variable.endswith('_yes') or self.variable.endswith('_no'):
         self.field_type_guess = 'yesno'
-        self.field_data_type_guess = None
         name_no_suffix = self.variable[:-3] if self.variable.endswith('_no') else self.variable[:-4]
         self.variable_name_guess = name_no_suffix.replace('_', ' ').capitalize()
     elif pdf_field_tuple[4] == '/Btn':
         self.field_type_guess = 'yesno'
-        self.field_data_type_guess = None
         self.variable_name_guess = variable_name_guess
     elif pdf_field_tuple[4] == "/Sig":
         self.field_type_guess = "signature"
-        self.field_data_type_guess = None
         self.variable_name_guess = variable_name_guess
     else:
         self.field_type_guess = 'text'
-        self.field_data_type_guess = 'text'
         self.variable_name_guess = variable_name_guess
     self.maxlength = get_character_limit(pdf_field_tuple)
 
@@ -259,13 +251,13 @@ class DAField(DAObject):
     elif self.field_type == 'area':
       content += "    input type: area\n"
       content += self._maxlength_str() + '\n'
-    elif self.field_data_type in ['integer', 'currency', 'email', 'range', 'number', 'date']:
-      content += "    datatype: {}\n".format(self.field_data_type)
-      if self.field_data_type in ['integer', 'currency']:
+    elif self.field_type in ['integer', 'currency', 'email', 'range', 'number', 'date']:
+      content += "    datatype: {}\n".format(self.field_type)
+      if self.field_type in ['integer', 'currency']:
         content += "    min: 0\n"
-      elif self.field_data_type == 'email':
+      elif self.field_type == 'email':
         content += self._maxlength_str() + '\n'
-      elif self.field_data_type == 'range':
+      elif self.field_type == 'range':
         content += "    min: {}\n".format(self.range_min)
         content += "    max: {}\n".format(self.range_max)
         content += "    step: {}\n".format(self.range_step)
@@ -290,18 +282,18 @@ class DAField(DAObject):
     if hasattr(self, 'field_type'):
       if self.field_type in ['yesno', 'yesnomaybe']:
         content += indent_by('${ word(yesno(' + field_name_to_use + ')) }', 6)
-      elif self.field_data_type in ['integer', 'number','range']:
+      elif self.field_type in ['integer', 'number','range']:
         content += indent_by('${ ' + field_name_to_use + ' }', 6)
       elif self.field_type == 'area':
         content += indent_by('> ${ single_paragraph(' + field_name_to_use + ') }', 6)
       elif self.field_type == 'file':
         content += "      \n"
         content += indent_by('${ ' + field_name_to_use + ' }', 6)
-      elif self.field_data_type == 'currency':
+      elif self.field_type == 'currency':
         content += indent_by('${ currency(' + field_name_to_use + ') }', 6)
-      elif self.field_data_type == 'date':
+      elif self.field_type == 'date':
         content += indent_by('${ ' + field_name_to_use + '.format() }', 6)
-      # elif field.field_data_type == 'email':
+      # elif field.field_type == 'email':
       else:
         content += indent_by('${ ' + field_name_to_use + ' }', 6)
     else:
@@ -314,9 +306,9 @@ class DAField(DAObject):
     # To avoid duplicate key error
     field_varname = varname(self.variable)
     content = '      - "{}": '.format(self.variable)
-    if hasattr(self, 'field_data_type') and self.field_data_type == 'date':
+    if hasattr(self, 'field_type') and self.field_type == 'date':
         content += '${ ' + field_varname.format() + ' }\n'
-    elif hasattr(self, 'field_data_type') and self.field_data_type == 'currency':
+    elif hasattr(self, 'field_type') and self.field_type == 'currency':
         content += '${ currency(' + field_varname + ') }\n'
     elif self.field_type_guess == 'signature': 
       comment = "      # It's a signature: test which file version this is; leave empty unless it's the final version)\n"
@@ -342,17 +334,10 @@ class DAField(DAObject):
       'default': self.variable_name_guess
     })
     field_questions.append({
-      'label': "Input style",
+      'label': "Input Type",
       'field': 'fields[' + str(index) + '].field_type',
-      'choices': ['yesno', 'text', 'area'], 
+      'choices': ['text', 'area', 'yesno', 'integer', 'number', 'currency', 'date', 'email'], 
       'default': self.field_type_guess if hasattr(self, 'field_type_guess') else None
-    })
-    field_questions.append({
-      'label': "Datatype",
-      'field': 'fields[' + str(index) + '].field_data_type',
-      'choices': ['text', 'integer', 'number', 'currency', 'date', 'email'],
-      'default': self.field_data_type_guess if hasattr(self, 'field_data_type_guess') else None,
-      'hide if': {'variable': 'fields[' + str(index) + '].field_type', 'is': 'yesno'}
     })
     return field_questions
 

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -336,7 +336,7 @@ class DAField(DAObject):
       'default': self.variable_name_guess
     })
     field_questions.append({
-      'label': "Input Type",
+      'label': "Field Type",
       'field': 'fields[' + str(index) + '].field_type',
       'choices': ['text', 'area', 'yesno', 'integer', 'number', 'currency', 'date', 'email'], 
       'default': self.field_type_guess if hasattr(self, 'field_type_guess') else None

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -310,6 +310,8 @@ class DAField(DAObject):
         content += '${ ' + field_varname.format() + ' }\n'
     elif hasattr(self, 'field_type') and self.field_type == 'currency':
         content += '${ currency(' + field_varname + ') }\n'
+    elif hasattr(self, 'field_type') and self.field_type == 'number':
+        content += r'${ "{:,.2f}".format(' + field_varname + ') }\n' 
     elif self.field_type_guess == 'signature': 
       comment = "      # It's a signature: test which file version this is; leave empty unless it's the final version)\n"
       content = comment + content + '${ ' + map_names(field_varname) + " if i == 'final' else '' }\n"

--- a/docassemble/assemblylinewizard/test_fill_in_field_attributes.py
+++ b/docassemble/assemblylinewizard/test_fill_in_field_attributes.py
@@ -12,7 +12,6 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
         self.assertEqual(new_field.docassemble_variable, 'field_name')
         self.assertEqual(new_field.has_label, True)
         self.assertEqual(new_field.field_type_guess, 'text')
-        self.assertEqual(new_field.field_data_type_guess, 'text')
         self.assertEqual(new_field.variable_name_guess, 'Field name')
 
     def test_date_field(self):
@@ -22,8 +21,7 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
         self.assertEqual(new_field.variable, 'birth_date')
         self.assertEqual(new_field.docassemble_variable, 'birth_date')
         self.assertEqual(new_field.has_label, True)
-        self.assertEqual(new_field.field_type_guess, 'text')
-        self.assertEqual(new_field.field_data_type_guess, 'date')
+        self.assertEqual(new_field.field_type_guess, 'date')
         self.assertEqual(new_field.variable_name_guess, 'Date of birth')
 
     def test_yes_text_field(self):
@@ -34,7 +32,6 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
         self.assertEqual(new_field.docassemble_variable, 'has_ssn_yes')
         self.assertEqual(new_field.has_label, True)
         self.assertEqual(new_field.field_type_guess, 'yesno')
-        self.assertEqual(new_field.field_data_type_guess, None)
         self.assertEqual(new_field.variable_name_guess, 'Has ssn')
 
     def test_no_text_field(self):
@@ -45,7 +42,6 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
         self.assertEqual(new_field.docassemble_variable, 'has_ssn_no')
         self.assertEqual(new_field.has_label, True)
         self.assertEqual(new_field.field_type_guess, 'yesno')
-        self.assertEqual(new_field.field_data_type_guess, None)
         self.assertEqual(new_field.variable_name_guess, 'Has ssn')
 
     def test_yesno_btn_field(self):
@@ -56,7 +52,6 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
         self.assertEqual(new_field.docassemble_variable, 'has_ssn')
         self.assertEqual(new_field.has_label, True)
         self.assertEqual(new_field.field_type_guess, 'yesno')
-        self.assertEqual(new_field.field_data_type_guess, None)
         self.assertEqual(new_field.variable_name_guess, 'Has ssn')
 
     def test_sig_field(self):
@@ -67,9 +62,7 @@ class test_fill_in_pdf_attributes(unittest.TestCase):
         self.assertEqual(new_field.docassemble_variable, 'signature')
         self.assertEqual(new_field.has_label, True)
         self.assertEqual(new_field.field_type_guess, 'signature')
-        self.assertEqual(new_field.field_data_type_guess, None)
         self.assertEqual(new_field.variable_name_guess, 'Signature')
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #38, #89

Requires #187 to be merged to master before this. 

Two sightly related fixes:
* #89 talks about merging the distinct uses of 'input type' and 'data type' when showing fields to the user. We can actually combine those two fields without losing information: all special data types don't make a ton of sense with the "area" or "yesno" field types. So we can combine everything into a single selection (which IMO makes more sense as a developer too. There is a difference between input type and the underlying data type, but the underlying data type should really determine the input type).
* #38: is a simply python formatted string. @nonprofittechy mentioned something about `thousands`, but I couldn't find anything about that in docassemble, and could only find https://docassemble.org/docs/markup.html#formatting. It works, but isn't locale specific, which seems good for now. 