### PR TITLE
Allow modifying court choices as constants, or during weaving

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -21,7 +21,8 @@ features:
 modules:
   - docassemble.base.util
   - docassemble.base.logger
-  - .interview_generator  
+  - .interview_generator
+  - .generator_constants
 ---
 objects:
   - generator_data: DAStore.using(base='interview', encrypted=False) # store sequential use of this generator
@@ -157,12 +158,13 @@ fields:
       - Other: other
   - Allowed courts: interview.allowed_courts
     datatype: checkboxes
+    none of the above: false
     code: |
-      generator_constants.AllOWED_COURTS
-  - Alternate Allowed courts: interview.allowed_courts_text
-    datatype: area
-    show if: | 
-      len(interview.allowed_courts.true_values()) == 0
+      get_allowed_courts() + ['Other']
+  - Alternate Allowed Courts (separate with a comma): interview.allowed_courts_text
+    input type: area
+    required: False
+    show if: interview.allowed_courts['Other']
   - Categories: interview.categories
     datatype: checkboxes
     choices:
@@ -409,6 +411,12 @@ code: |
   add_draft_intro_screen = True
 ---
 code: |
+  # HACK(brycew): could be a better place to put it, but can't find one :/
+  if defined('interview.allowed_courts_text') and len(interview.allowed_courts_text) > 0:
+    # 'Other' had to marked true, but is itself useless
+    interview.allowed_courts['Other'] = False
+    for allowed_court in interview.allowed_courts_text.split(','):
+      interview.allowed_courts[allowed_court.strip()] = True
   # Build the dictionary of info we want the interview
   # to know about itself.
   metadata.comment = 'The metadata section controls the tab title and saved interview title. You can delete this section if you include this YAML file in another YAML file.'

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -157,24 +157,12 @@ fields:
       - Other: other
   - Allowed courts: interview.allowed_courts
     datatype: checkboxes
-    choices:
-      - Boston Municipal Court
-      - District Court
-      - Superior Court
-      - Housing Court
-      - Probate and Family Court
-      - Juvenile Court
-      - Land Court
-  # - Preferred court: interview.preferred_court
-  #   choices:
-  #     - Boston Municipal Court
-  #     - District Court
-  #     - Superior Court
-  #     - Housing Court
-  #     - Probate and Family Court
-  #     - Juvenile Court
-  #     - Land Court
-  #     - Any court (no preferred court)
+    code: |
+      generator_constants.AllOWED_COURTS
+  - Alternate Allowed courts: interview.allowed_courts_text
+    datatype: area
+    show if: | 
+      len(interview.allowed_courts.true_values()) == 0
   - Categories: interview.categories
     datatype: checkboxes
     choices:
@@ -570,7 +558,6 @@ code: |
   logic_list.append('al_intro_screen') # Splash page for your organization
   logic_list.append(interview_label + '_intro')
   logic_list.append('# Set the allowed courts for this interview')
-  # logic_list.append('preferred_court = interview_metadata["' + interview_label + '"]["preferred court"]')
   logic_list.append('allowed_courts = interview_metadata["' + interview_label + '"]["allowed courts"]')
   # The placeholder section label just reviews all of the questions
   logic_list.append("nav.set_section('" + "review_" + interview_label + "')")

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -160,7 +160,7 @@ fields:
     datatype: checkboxes
     none of the above: false
     code: |
-      get_allowed_courts() + ['Other']
+      get_court_choices() + ['Other']
   - Alternate Allowed Courts (separate with a comma): interview.allowed_courts_text
     input type: area
     required: False

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -194,6 +194,5 @@ generator_constants.ALLOWED_COURTS = [
   'Housing Court',
   'Probate and Family Court',
   'Juvenile Court',
-  'Land Court',
-  'Other'
+  'Land Court'
 ]

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -185,3 +185,15 @@ generator_constants.UNMAP_SUFFIXES = {
   ".mail_address.line_one()": ".mail_address.address",
   ".mail_address.line_two()": ".mail_address.address",
 }
+
+# Court Choices
+generator_constants.ALLOWED_COURTS = [
+  'Boston Municipal Court',
+  'District Court',
+  'Superior Court',
+  'Housing Court',
+  'Probate and Family Court',
+  'Juvenile Court',
+  'Land Court',
+  'Other'
+]

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -186,8 +186,8 @@ generator_constants.UNMAP_SUFFIXES = {
   ".mail_address.line_two()": ".mail_address.address",
 }
 
-# Court Choices
-generator_constants.ALLOWED_COURTS = [
+# Possible values for 'Allowed Courts', when looking up courts to submit to
+generator_constants.COURT_CHOICES = [
   'Boston Municipal Court',
   'District Court',
   'Superior Court',

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -22,7 +22,7 @@ from .generator_constants import generator_constants
 
 TypeType = type(type(None))
 
-__all__ = ['Playground', 'PlaygroundSection', 'indent_by', 'varname', 'DAField', 'DAFieldList', 'DAQuestion', 'DAInterview', 'DAAttachmentList', 'DAAttachment', 'to_yaml_file', 'base_name', 'to_package_name', 'oneline', 'DAQuestionList', 'map_names', 'trigger_gather_string', 'is_reserved_label', 'attachment_download_html', 'get_fields','is_reserved_docx_label','get_character_limit', 'create_package_zip', 'get_person_variables', 'get_allowed_courts']
+__all__ = ['Playground', 'PlaygroundSection', 'indent_by', 'varname', 'DAField', 'DAFieldList', 'DAQuestion', 'DAInterview', 'DAAttachmentList', 'DAAttachment', 'to_yaml_file', 'base_name', 'to_package_name', 'oneline', 'DAQuestionList', 'map_names', 'trigger_gather_string', 'is_reserved_label', 'attachment_download_html', 'get_fields','is_reserved_docx_label','get_character_limit', 'create_package_zip', 'get_person_variables', 'get_court_choices']
 
 always_defined = set(["False", "None", "True", "dict", "i", "list", "menu_items", "multi_user", "role", "role_event", "role_needed", "speak_text", "track_location", "url_args", "x", "nav", "PY2", "string_types"])
 replace_square_brackets = re.compile(r'\\\[ *([^\\]+)\\\]')
@@ -34,8 +34,8 @@ digit_start = re.compile(r'^[0-9]+')
 newlines = re.compile(r'\n')
 remove_u = re.compile(r'^u')
 
-def get_allowed_courts():
-  return generator_constants.ALLOWED_COURTS
+def get_court_choices():
+  return generator_constants.COURT_CHOICES
 
 def attachment_download_html(url, label):
   return '<a href="' + url + '" download="">' + label + '</a>'

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -22,7 +22,7 @@ from .generator_constants import generator_constants
 
 TypeType = type(type(None))
 
-__all__ = ['Playground', 'PlaygroundSection', 'indent_by', 'varname', 'DAField', 'DAFieldList', 'DAQuestion', 'DAInterview', 'DAAttachmentList', 'DAAttachment', 'to_yaml_file', 'base_name', 'to_package_name', 'oneline', 'DAQuestionList', 'map_names', 'trigger_gather_string', 'is_reserved_label', 'attachment_download_html', 'get_fields','is_reserved_docx_label','get_character_limit', 'create_package_zip', 'get_person_variables']
+__all__ = ['Playground', 'PlaygroundSection', 'indent_by', 'varname', 'DAField', 'DAFieldList', 'DAQuestion', 'DAInterview', 'DAAttachmentList', 'DAAttachment', 'to_yaml_file', 'base_name', 'to_package_name', 'oneline', 'DAQuestionList', 'map_names', 'trigger_gather_string', 'is_reserved_label', 'attachment_download_html', 'get_fields','is_reserved_docx_label','get_character_limit', 'create_package_zip', 'get_person_variables', 'get_allowed_courts']
 
 always_defined = set(["False", "None", "True", "dict", "i", "list", "menu_items", "multi_user", "role", "role_event", "role_needed", "speak_text", "track_location", "url_args", "x", "nav", "PY2", "string_types"])
 replace_square_brackets = re.compile(r'\\\[ *([^\\]+)\\\]')
@@ -33,6 +33,9 @@ invalid_var_characters = re.compile(r'[^A-Za-z0-9_]+')
 digit_start = re.compile(r'^[0-9]+')
 newlines = re.compile(r'\n')
 remove_u = re.compile(r'^u')
+
+def get_allowed_courts():
+  return generator_constants.ALLOWED_COURTS
 
 def attachment_download_html(url, label):
   return '<a href="' + url + '" download="">' + label + '</a>'


### PR DESCRIPTION
Fixes #132.

Some of the choices I made feel a little hacky; I couldn't find a better place to get docassemble to run the `interview.allowed_courts_text` conversion than in the one block that it's used. Let me know if there's an better solution there that I missed.

Example of the UI is show below:

![Screenshot from 2021-02-05 17-33-21](https://user-images.githubusercontent.com/6252212/107096259-4f8a6980-67d8-11eb-8c9c-837f0a487ce4.png)
