### PR TITLE
Close #193, replace underscores with dashes in user-facing file names. One line.

### DIFF
--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -426,7 +426,7 @@ class DAQuestion(DAObject):
                     content += "attachment:\n"
                     content += "    variable name: " + self.attachment_variable_name + "[i]\n"
                     content += "    name: " + oneline(attachment.name) + "\n"
-                    content += "    filename: " + varname(attachment.name) + "\n"
+                    content += "    filename: " + varname(attachment.name).replace('_', '-') + "\n"
                     if attachment.type == 'md':
                         content += "    content: " + oneline(attachment.content) + "\n"
                     elif attachment.type == 'pdf':


### PR DESCRIPTION
Closes #193. Test:
- [ ] `filename:` has dashes in `attachment:` block for [test_pdf.pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/5945662/test_pdf.pdf)
- [ ] (optional) `filename:` has dashes in `attachment:` block for [test_docx.docx](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/5945671/test_docx.docx)

