### PR TITLE
Close #207, add singular Person prefix to global_constants (trial_court)

### DIFF
--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -14,8 +14,9 @@ generator_constants.RESERVED_WHOLE_WORDS = [
   #'attorney_of_record_address_on_one_line',
 ]
 
-# Singular person object prefixes that we deliberately leave undefined
-generator_constants.PERSON_PREFIXES = [
+# Prefixes for singular person-like objects, like trial courts that
+# should be left undefined to trigger their question
+generator_constants.UNDEFINED_PERSON_PREFIXES = [
   "trial_court",
 ]
 
@@ -169,6 +170,7 @@ generator_constants.RESERVED_SUFFIXES_MAP = {**generator_constants.PEOPLE_SUFFIX
   # '_name_short': not implemented,
   '_division': ".division",
   '_county': ".address.county",
+  '_department': ".department",
 }}
 
 # these might be used in a docx, but we don't transform PDF fields to use these

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -14,7 +14,12 @@ generator_constants.RESERVED_WHOLE_WORDS = [
   #'attorney_of_record_address_on_one_line',
 ]
 
-# Vars representing people
+# Singular person object prefixes
+generator_constants.PERSON_PREFIXES = [
+  "trial_court",
+]
+
+# Plural vars representing people
 generator_constants.PEOPLE_VARS = [
   'users',
   'other_parties',
@@ -43,6 +48,7 @@ generator_constants.RESERVED_VAR_PLURALS = generator_constants.PEOPLE_VARS + [
   'docket_numbers',
 ]
 
+# Prefixes as they would appear in a PDF (singular)
 generator_constants.RESERVED_PREFIXES = (r"^(user"  # deprecated, but still supported
   + r"|other_party"  # deprecated, but still supported
   + r"|child"
@@ -67,6 +73,7 @@ generator_constants.RESERVED_PREFIXES = (r"^(user"  # deprecated, but still supp
   + r"|guardian"
   + r"|decedent"
   + r"|interested_party"
+  + r"|trial_court"
   + r")")
 
 # reserved_pluralizers_map

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -14,7 +14,7 @@ generator_constants.RESERVED_WHOLE_WORDS = [
   #'attorney_of_record_address_on_one_line',
 ]
 
-# Singular person object prefixes
+# Singular person object prefixes that we deliberately leave undefined
 generator_constants.PERSON_PREFIXES = [
   "trial_court",
 ]

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1292,7 +1292,7 @@ def get_person_variables(fieldslist,
       # See regex GitHub issue:
       # https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/issues/205
       # TAKE CARE to double check new possible partial matches to suffixes
-      match_pdf_person_suffixes = r"(.+?)(?:(" + "$)|(".join(people_suffixes_map.keys()) + "$))"
+      match_pdf_person_suffixes = r"(.+?)(?:($)|(".join(people_suffixes_map.keys()) + "$))"
       matches = re.match(match_pdf_person_suffixes, field_to_check)
       if matches:
         if matches.groups()[0] in undefined_person_prefixes:

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1080,10 +1080,7 @@ def map_names(label, document_type="pdf", reserved_whole_words=generator_constan
   prefix = label_groups[1]
   # Map prefix to an adjusted version
   # At the moment, turn any singluars into plurals if needed, e.g. 'user' into 'users'
-  try:
-    adjusted_prefix = reserved_pluralizers_map[prefix]
-  except:
-    adjusted_prefix = prefix
+  adjusted_prefix = reserved_pluralizers_map.get(prefix, prefix)
   # With reserved plurals, we're always using an index
   # of the plural version of the prefix of the label
   if adjusted_prefix in reserved_var_plurals:

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1051,7 +1051,7 @@ def get_docx_variables( text ):
 
 def map_names(label, document_type="pdf", reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
               reserved_prefixes=generator_constants.RESERVED_PREFIXES,
-              single_person_prefixes=generator_constants.PERSON_PREFIXES,
+              undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
               reserved_var_plurals=generator_constants.RESERVED_VAR_PLURALS,
               reserved_pluralizers_map = generator_constants.RESERVED_PLURALIZERS_MAP,
               reserved_suffixes_map=generator_constants.RESERVED_SUFFIXES_MAP):
@@ -1066,7 +1066,7 @@ def map_names(label, document_type="pdf", reserved_whole_words=generator_constan
 
   if (label in reserved_whole_words
    or label in reserved_var_plurals
-   or label in single_person_prefixes):
+   or label in undefined_person_prefixes):
      return label
 
   # Break up label into its parts: prefix, digit, the rest
@@ -1110,7 +1110,7 @@ def map_names(label, document_type="pdf", reserved_whole_words=generator_constan
 
 def trigger_gather_string(docassemble_var,
                           reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
-                          single_person_prefixes=generator_constants.PERSON_PREFIXES,
+                          undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
                           reserved_var_plurals=generator_constants.RESERVED_VAR_PLURALS,
                           reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP):
   """Turn the docassemble variable string into an expression
@@ -1133,7 +1133,7 @@ def trigger_gather_string(docassemble_var,
   # The prefix, ensuring no key or index
   prefix = re.sub(r'\[.+\]', '', var_parts[0][0])
   has_plural_prefix = prefix in reserved_pluralizers_map.values()
-  has_singular_prefix = prefix in single_person_prefixes
+  has_singular_prefix = prefix in undefined_person_prefixes
 
   if has_plural_prefix or has_singular_prefix:
     first_attribute = var_parts[0][1]
@@ -1149,7 +1149,7 @@ def trigger_gather_string(docassemble_var,
 
 def is_reserved_docx_label(label, docx_only_suffixes=generator_constants.DOCX_ONLY_SUFFIXES,
                            reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
-                           single_person_prefixes=generator_constants.PERSON_PREFIXES,
+                           undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
                            reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP,
                            reserved_suffixes_map=generator_constants.RESERVED_SUFFIXES_MAP):
     '''Given a string, will return whether the string matches
@@ -1166,7 +1166,7 @@ def is_reserved_docx_label(label, docx_only_suffixes=generator_constants.DOCX_ON
     # The prefix, ensuring no key or index
     # Not sure this handles keys/attributes
     prefix = re.sub(r'\[.+\]', '', label_parts[0][0])
-    is_reserved = prefix in reserved_pluralizers_map.values() or prefix in single_person_prefixes
+    is_reserved = prefix in reserved_pluralizers_map.values() or prefix in undefined_person_prefixes
 
     if is_reserved:
       suffix = label_parts[0][1]
@@ -1250,7 +1250,7 @@ def indexify(digit):
     return '[' + str(int(digit)-1) + ']'
 
 def get_person_variables(fieldslist,
-                         single_person_prefixes = generator_constants.PERSON_PREFIXES,
+                         undefined_person_prefixes = generator_constants.UNDEFINED_PERSON_PREFIXES,
                          people_vars = generator_constants.PEOPLE_VARS,
                          people_suffixes = generator_constants.PEOPLE_SUFFIXES,
                          people_suffixes_map = generator_constants.PEOPLE_SUFFIXES_MAP,
@@ -1270,7 +1270,7 @@ def get_person_variables(fieldslist,
       field_to_check = field
     if (field_to_check) in people_vars:
       people.add(field_to_check)
-    elif (field_to_check) in single_person_prefixes:
+    elif (field_to_check) in undefined_person_prefixes:
       pass  # Do not ask how many there will be about a singluar person
     elif '[' in field_to_check or '.' in field_to_check:
       # Check for a valid Python identifier before brackets or .
@@ -1278,7 +1278,7 @@ def get_person_variables(fieldslist,
       matches = re.match(match_with_brackets_or_attribute, field_to_check)
       if matches:
         # Do not ask how many there will be about a singluar person
-        if matches.groups()[0] in single_person_prefixes:
+        if matches.groups()[0] in undefined_person_prefixes:
           pass
         # Is the name before attribute/index a predetermined person?  
         elif matches.groups()[0] in people_vars:
@@ -1298,7 +1298,7 @@ def get_person_variables(fieldslist,
       match_pdf_person_suffixes = r"(.+?)(?:(" + "$)|(".join(people_suffixes_map.keys()) + "$))"
       matches = re.match(match_pdf_person_suffixes, field_to_check)
       if matches:
-        if matches.groups()[0] in single_person_prefixes:
+        if matches.groups()[0] in undefined_person_prefixes:
           # Do not ask how many there will be about a singluar person
           pass
         else:

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1110,6 +1110,7 @@ def map_names(label, document_type="pdf", reserved_whole_words=generator_constan
 
 def trigger_gather_string(docassemble_var,
                           reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
+                          singular_prefixes=generator_constants.PERSON_PREFIXES,
                           reserved_var_plurals=generator_constants.RESERVED_VAR_PLURALS,
                           reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP):
   """Turn the docassemble variable string into an expression
@@ -1132,10 +1133,11 @@ def trigger_gather_string(docassemble_var,
   # The prefix, ensuring no key or index
   prefix = re.sub(r'\[.+\]', '', var_parts[0][0])
   has_plural_prefix = prefix in reserved_pluralizers_map.values()
+  has_singular_prefix = prefix in singular_prefixes
 
-  if has_plural_prefix:
+  if has_plural_prefix or has_singular_prefix:
     first_attribute = var_parts[0][1]
-    if first_attribute == '' or first_attribute == '.name':
+    if has_plural_prefix and (first_attribute == '' or first_attribute == '.name'):
       return prefix + GATHER_CALL
     elif first_attribute == '.address' or first_attribute == '.mail_address':
       return var_parts[0][0] + first_attribute + '.address'

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1147,6 +1147,7 @@ def trigger_gather_string(docassemble_var,
 
 def is_reserved_docx_label(label, docx_only_suffixes=generator_constants.DOCX_ONLY_SUFFIXES,
                            reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
+                           singular_prefixes=generator_constants.PERSON_PREFIXES,
                            reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP,
                            reserved_suffixes_map=generator_constants.RESERVED_SUFFIXES_MAP):
     '''Given a string, will return whether the string matches
@@ -1161,10 +1162,11 @@ def is_reserved_docx_label(label, docx_only_suffixes=generator_constants.DOCX_ON
     if not label_parts[0]:
       return False
     # The prefix, ensuring no key or index
+    # Not sure this handles keys/attributes
     prefix = re.sub(r'\[.+\]', '', label_parts[0][0])
-    has_plural_prefix = prefix in reserved_pluralizers_map.values()
+    is_reserved = prefix in reserved_pluralizers_map.values() or prefix in singular_prefixes
 
-    if has_plural_prefix:
+    if is_reserved:
       suffix = label_parts[0][1]
       if not suffix:  # If only the prefix
         return True

--- a/docassemble/assemblylinewizard/test_map_names.py
+++ b/docassemble/assemblylinewizard/test_map_names.py
@@ -55,6 +55,12 @@ attachment_scenarios = {
   # "county_division": not implemented,
   "court_address_county": "courts[0].address.county",
   "court_county": "courts[0].address.county",
+  
+  # Singluar prefixes that still have suffixes
+  "trial_court": "trial_court",
+  "trial_court_address_county": "trial_court.address.county",
+  "trial_court_county": "trial_court.address.county",
+  "trial_court_division": "trial_court.division",
 
   # # Reserved starts (with names)
   "user": "users[0]",
@@ -143,6 +149,12 @@ interview_order_scenarios = {
   "court_address_county": "courts[0].address.address",
   "court_county": "courts[0].address.address",
 
+  # Singluar prefixes that still have suffixes
+  "trial_court": "trial_court",
+  #"trial_court_address_county": "trial_court.address",  # not desired?
+  "trial_court_county": "trial_court.address",
+  "trial_court_division": "trial_court.division",
+
   # # Reserved starts (with names)
   "user": "users.gather()",
   "users": "users.gather()",
@@ -156,6 +168,12 @@ interview_order_scenarios = {
 
   "defendant1_name": "defendants.gather()",
   "defendant1_email": "defendants[0].email",
+  
+  # Singluar prefixes that still have suffixes
+  "trial_court": "trial_court",
+  "trial_court_county": "trial_court.address",
+  #"trial_court_address_county": "trial_court.address.county",  # not desired
+  "trial_court_division": "trial_court.division",
 
   # Starts with no names
   "docket_number": "docket_numbers.gather()",

--- a/docassemble/assemblylinewizard/test_map_names.py
+++ b/docassemble/assemblylinewizard/test_map_names.py
@@ -151,7 +151,7 @@ interview_order_scenarios = {
 
   # Singluar prefixes that still have suffixes
   "trial_court": "trial_court",
-  #"trial_court_address_county": "trial_court.address",  # not desired?
+  "trial_court_address_county": "trial_court.address",
   "trial_court_county": "trial_court.address",
   "trial_court_division": "trial_court.division",
 
@@ -168,12 +168,6 @@ interview_order_scenarios = {
 
   "defendant1_name": "defendants.gather()",
   "defendant1_email": "defendants[0].email",
-  
-  # Singluar prefixes that still have suffixes
-  "trial_court": "trial_court",
-  "trial_court_county": "trial_court.address",
-  #"trial_court_address_county": "trial_court.address.county",  # not desired
-  "trial_court_division": "trial_court.division",
 
   # Starts with no names
   "docket_number": "docket_numbers.gather()",

--- a/docassemble/assemblylinewizard/test_map_names.py
+++ b/docassemble/assemblylinewizard/test_map_names.py
@@ -151,8 +151,8 @@ interview_order_scenarios = {
 
   # Singluar prefixes that still have suffixes
   "trial_court": "trial_court",
-  "trial_court_address_county": "trial_court.address",
-  "trial_court_county": "trial_court.address",
+  "trial_court_address_county": "trial_court.address.address",
+  "trial_court_county": "trial_court.address.address",
   "trial_court_division": "trial_court.division",
 
   # # Reserved starts (with names)

--- a/docassemble/assemblylinewizard/test_map_names.py
+++ b/docassemble/assemblylinewizard/test_map_names.py
@@ -61,6 +61,7 @@ attachment_scenarios = {
   "trial_court_address_county": "trial_court.address.county",
   "trial_court_county": "trial_court.address.county",
   "trial_court_division": "trial_court.division",
+  "trial_court_department": "trial_court.department",
 
   # # Reserved starts (with names)
   "user": "users[0]",
@@ -154,6 +155,7 @@ interview_order_scenarios = {
   "trial_court_address_county": "trial_court.address.address",
   "trial_court_county": "trial_court.address.address",
   "trial_court_division": "trial_court.division",
+  "trial_court_department": "trial_court.department",
 
   # # Reserved starts (with names)
   "user": "users.gather()",


### PR DESCRIPTION
Closes #207. [Also uses and thus closes #205. For the regex used, see the last link in that issue. Does it also close #179?] Took care of it in 4 places:
1. PDF var name mapping
2. DOCX var name mapping
3. With trigger gather var names
4. When collecting people

I treated it like a person who is singular as it seemed to match those criteria in behavior.

Test 1:
- [ ] Test file passes [the `trial_courts` test. They won't pass two of the courts' tests because the test framework was updated and I didn't want to conflict with master. We'll have to work all that out after.]

Test 2:
Use ([trial_court.pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/5951154/trial_court.pdf)) and see that `trial_court`:
- [ ] is not asked about as a person
- [ ] is in the interview order block
- [ ] does not have `.gather()` on it
- [ ] its `.address` is in the interview order block (though this will be updated when master gets merged in)
- [ ] its `.division` is in the interview order block
- [ ] is in the attachment block
- [ ] its `.address.county` is in the attachment block (though this will be updated when master gets merged in)
- [ ] its `.division` is in the attachment block

Test 3:
Use ([trial_court.docx](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/5951187/trial_court.docx)) and see that `trial_court`:
- [ ] is not asked about as a person
- [ ] is in the interview order block
- [ ] does not have `.gather()` on it
- [ ] its `.address` is in the interview order block (though this will be updated when master gets merged in)
- [ ] its `.division` is in the interview order block
- [ ] is in the attachment block
- [ ] its `.address.county` is in the attachment block (though this will be updated when master gets merged in)
- [ ] its `.division` is in the attachment block

Test 4:
Did I miss anything?

Notes:
1. There is a console log coming out of interview_generator and I'm wondering if that was left in on purpose.
1. It would be good to add tests for the `trigger gather` function and the people identification function for this but that was being edited elsewhere, so I didn't mess with it.
1. For demo of a variable being undefined and instantiated by a choice made of objects, see [this very small demo](https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALWeaver207SingularPrefixes%3Atrial_court_test.yml#page1). This is its code, using the var `trial_courts` for fun. Let me know if this code accurately represents the question we had about leaving it undefined:
```yml
---
objects:
  - macourts: DAList.using(object_type=DAObject)
---
code: |
  macourts.appendObject()
  macourts.appendObject()
  macourts[0].name = 'foo'
  macourts[1].name = 'bar'
  macourts.gathered = True
  macourts.there_is_another = False
  get_macourts = True
---
mandatory: True
code: |
  get_macourts
  trial_court
---
question: Courts
fields:
  - Trial court: trial_court
    datatype: radio
    code: |
      macourts
```