### PR TITLE
Review screen full display

### DIFF
--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -198,6 +198,14 @@ generator_constants.UNMAP_SUFFIXES = {
   ".mail_address.line_two()": ".mail_address.address",
 }
 
+generator_constants.FULL_DISPLAY = {
+  '.name': '.name.full()',
+  '.address': '.address.block()',
+  '.mail_address': '.mail_address.block()',
+  '.division': '',  # part of the court object, need to reselect the whole thing,
+  '.department': ''
+}
+
 # Possible values for 'Allowed Courts', when looking up courts to submit to
 generator_constants.COURT_CHOICES = [
   'Boston Municipal Court',

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -217,9 +217,9 @@ class DAField(DAObject):
     # this will let us edit the name field if document just refers to
     # the whole object
     if new_field_name in reserved_pluralizers_map.values():
-      self.edit_attribute = new_field_name + '[0].name.first'
+      self.edit_attribute = new_field_name + '[0].name'
     if new_field_name in [label + '[0]' for label in reserved_pluralizers_map.values()]:
-      self.edit_attribute = new_field_name + '.name.first'
+      self.edit_attribute = new_field_name + '.name'
 
     # variable_name_guess is the placeholder label for the field
     variable_name_guess = self.variable.replace('_', ' ').capitalize()

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -292,6 +292,8 @@ class DAField(DAObject):
       return ""
 
   def field_entry_yaml(self, document_type):
+    log("{}: {}".format(self.raw_field_name, self.variable), "console")
+    log("{}".format(self.final_display_var), "console")
     settable_version = unmap(self.final_display_var)
     content = ""
     if self.has_label:
@@ -321,6 +323,8 @@ class DAField(DAObject):
     return content
 
   def review_yaml(self, document_type, reviewed_fields):
+    log("{}: {}".format(self.raw_field_name, self.variable), "console")
+    log("{}".format(self.final_display_var), "console")
     settable_var = unmap(self.final_display_var)
     if settable_var in reviewed_fields:
       return ""
@@ -477,6 +481,7 @@ class DAQuestion(DAObject):
             content += 'progress: ' + self.progress + '\n'
         if hasattr(self, 'is_mandatory') and self.is_mandatory:
             content += "mandatory: True\n"
+        log('in question, of type {}, content: {}'.format(self.type, content), 'console')
         # TODO: refactor. Too many things shoved into "question"
         if self.type == 'question':
             done_with_content = False
@@ -727,6 +732,7 @@ class DAQuestion(DAObject):
           content += "review: \n"
           reviewed_fields = set()
           for field in self.field_list:
+              log('at review for {}'.format(field.raw_field_name), 'console')
               content += field.review_yaml(document_type, reviewed_fields)
         return content
 

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -214,13 +214,6 @@ class DAField(DAObject):
     self.final_display_var = new_field_name  # no transformation changes
     self.has_label = True
 
-    # this will let us edit the name field if document just refers to
-    # the whole object
-    if new_field_name in reserved_pluralizers_map.values():
-      self.edit_attribute = new_field_name + '[0].name'
-    if new_field_name in [label + '[0]' for label in reserved_pluralizers_map.values()]:
-      self.edit_attribute = new_field_name + '.name'
-
     # variable_name_guess is the placeholder label for the field
     variable_name_guess = self.variable.replace('_', ' ').capitalize()
     if self.raw_field_name.endswith('_date'):
@@ -439,8 +432,6 @@ class DAField(DAObject):
 
     # Everything before the first period and everything from the first period to the end
     var_with_attribute = substitute_suffix(self.final_display_var, generator_constants.UNMAP_SUFFIXES)
-  # generator_constants.UNMAP_SUFFIXES):
-  # map address() etc backwards
     var_parts = re.findall(r'([^.]+)(\.[^.]*)?', var_with_attribute)
 
     # test for existence (empty strings result in a tuple)

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -466,6 +466,13 @@ class DAField(DAObject):
   def _get_base_variable(var_with_attribute,
                      undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
                      reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP):
+    """Gets the base object or list that holds the data that is in var_with_attribute
+    For example, users[0].name and users[1].name.last will both return users. 
+    NOTE: we only combine name attributes of lists right now. So users[0].address returns 
+    users[0].address and users[0].phone_number returns users[0].phone_number right now.
+    TODO(brycew): to handle all attributes correctly like that, we need the list of all attributes
+    used in the form, to show / edit them all in the same review/ revisit screen
+    """
     var_parts = re.findall(r'([^.]+)(\.[^.]*)?', var_with_attribute)
     if not var_parts:
       return var_with_attribute 
@@ -1295,10 +1302,12 @@ def is_reserved_label(label, reserved_whole_words = generator_constants.RESERVED
 ############################
 #  Label processing helper functions
 ############################
-def remove_multiple_appearance_indicator(label):
+def remove_multiple_appearance_indicator(label: str):
     return re.sub(r'_{2,}\d+', '', label)
 
-def substitute_suffix(label, suffixes): 
+def substitute_suffix(label: str, suffixes: map[str, str]) -> str: 
+  """If `label` ends with any of the keys in `suffixes`, replaces it with the corresponding value
+  """
   for suffix in suffixes:
     if label.endswith(suffix):
       return label.replace(suffix, suffixes[suffix])

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -276,7 +276,7 @@ class DAField(DAObject):
       self.variable = self.variable[:-4]
       self.final_display_var = self.final_display_var[:-4]
 
-  def get_single_field_screen(self, document_type):
+  def get_single_field_screen(self):
     settable_version = substitute_suffix(self.final_display_var, generator_constants.UNMAP_SUFFIXES)
     if self.field_type == 'yesno':
       return "yesno: {}\n".format(settable_version), True
@@ -291,7 +291,7 @@ class DAField(DAObject):
     else:
       return ""
 
-  def field_entry_yaml(self, document_type):
+  def field_entry_yaml(self) -> str:
     settable_var = substitute_suffix(self.final_display_var, generator_constants.UNMAP_SUFFIXES)
     content = ""
     if self.has_label:
@@ -320,7 +320,7 @@ class DAField(DAObject):
 
     return content
 
-  def review_yaml(self, document_type, reviewed_fields, reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP):
+  def review_yaml(self, reviewed_fields, reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP):
     settable_var = substitute_suffix(self.final_display_var, generator_constants.UNMAP_SUFFIXES)
     base_var = DAField._get_base_variable(settable_var)
 
@@ -465,7 +465,6 @@ class DAField(DAObject):
   @staticmethod
   def _get_base_variable(var_with_attribute,
                      undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
-                     reserved_var_plurals=generator_constants.RESERVED_VAR_PLURALS,
                      reserved_pluralizers_map=generator_constants.RESERVED_PLURALIZERS_MAP):
     var_parts = re.findall(r'([^.]+)(\.[^.]*)?', var_with_attribute)
     if not var_parts:
@@ -540,7 +539,7 @@ class DAQuestion(DAObject):
             if self.subquestion_text != "":
                 content += "subquestion: |\n" + indent_by(self.subquestion_text, 2)
             if len(self.field_list) == 1:
-                new_content, done_with_content = self.field_list[0].get_single_field_screen(document_type)
+                new_content, done_with_content = self.field_list[0].get_single_field_screen()
                 content += new_content
             if self.field_list[0].field_type == 'end_attachment':
                 #if hasattr(self, 'interview_label'):  # this tells us its the ending screen
@@ -585,7 +584,7 @@ class DAQuestion(DAObject):
             if not done_with_content:
                 content += "fields:\n"
                 for field in self.field_list:
-                    content += field.field_entry_yaml(document_type)
+                    content += field.field_entry_yaml()
 
         elif self.type == 'signature':
             content += "signature: " + varname(self.field_list[0].raw_field_name) + "\n"
@@ -772,8 +771,7 @@ class DAQuestion(DAObject):
           content += "review: \n"
           reviewed_fields = set()
           for field in self.field_list:
-              log('at review for {}'.format(field.raw_field_name), 'console')
-              content += field.review_yaml(document_type, reviewed_fields)
+              content += field.review_yaml(reviewed_fields)
         return content
 
 class DAQuestionList(DAList):

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -19,6 +19,7 @@ import datetime
 import zipfile
 import types
 import json
+from typing import Dict
 from .generator_constants import generator_constants
 
 TypeType = type(type(None))
@@ -336,11 +337,11 @@ class DAField(DAObject):
         
     if base_var in reserved_pluralizers_map.values():
       content += indent_by("# NOTE: a question block with '{}.revisit'".format(base_var), 6)
-      content += indend_by("# lets the user edit all of the items at once", 6)
+      content += indent_by("# lets the user edit all of the items at once", 6)
       content += indent_by(bold(base_var), 6) + '\n'
       content += indent_by("% for my_var in {}:".format(base_var), 6)
       content += indent_by("* ${ my_var }", 8)
-      content += indend_by("% endfor", 6)
+      content += indent_by("% endfor", 6)
       return content
     
     edit_display_name = self.label if hasattr(self, 'label') else settable_var
@@ -1296,7 +1297,7 @@ def is_reserved_label(label, reserved_whole_words = generator_constants.RESERVED
 def remove_multiple_appearance_indicator(label: str):
     return re.sub(r'_{2,}\d+', '', label)
 
-def substitute_suffix(label: str, suffixes: map[str, str]) -> str: 
+def substitute_suffix(label: str, suffixes: Dict[str, str]) -> str: 
   """If `label` ends with any of the keys in `suffixes`, replaces it with the corresponding value
   """
   for suffix in suffixes:


### PR DESCRIPTION
Tested a little, but still might have some (related or unrelated bugs). 

Main parts:
* replaces `unmap` with a more general `substitute_suffix`, from any dictionary
* adds a `_get_base_variable` to `DAField`, which gets the base list, object, or variable that holds the data for the field itself. This is used to make sure there aren't duplicates on the review screen. 


Should fix #59 and also fix #178, and a small portion of #64 (still need to handle the name I think). 