### PR TITLE
Fix #188, some display vars not being translated to settable vars

### DIFF
--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -184,18 +184,22 @@ generator_constants.DOCX_ONLY_SUFFIXES = [
     r'\.formatted_age\(\)'
 ]
 
-generator_constants.UNMAP_SUFFIXES = {
-  ".birthdate.format()": '.birthdate',
-  ".age_in_years()": ".birthdate",
-  ".name.middle_initial()": ".name.middle_name",
-  ".address.block()": ".address.address",
-  ".address.on_one_line()": ".address.address",
-  ".address.line_one()": ".address.address",
-  ".address.line_two()": ".address.address",
-  ".mail_address.block()": ".mail_address.address",
-  ".mail_address.on_one_line()": ".mail_address.address",
-  ".mail_address.line_one()": ".mail_address.address",
-  ".mail_address.line_two()": ".mail_address.address",
+generator_constants.DISPLAY_SUFFIX_TO_SETTABLE_SUFFIX = {
+  '\.address.block\(\)$': '.address.address',
+  '\.address.line_one\(\)$': '.address.address',
+  '\.address.line_two\(\)$': '.address.address',
+  '\.address.on_one_line\(\)$': '.address.address',
+  '\.age_in_years\(\)$': '.birthdate',
+  '\.birthdate.format\(.*\)$': '.birthdate',
+  '\.familiar_or\(\)$': '.name.first',
+  '\.familiar\(\)$': '.name.first',
+  '\.formatted_age\(.*\)$': '.birthdate',
+  '\.mail_address.block\(\)$': '.mail_address.address',
+  '\.mail_address.line_one\(\)$': '.mail_address.address',
+  '\.mail_address.line_two\(\)$': '.mail_address.address',
+  '\.mail_address.on_one_line\(\)$': '.mail_address.address',
+  '\.name.middle_initial\(\)$': '.name.first',
+  '\.phone_numbers\(\)$': '.phone_number',
 }
 
 # Possible values for 'Allowed Courts', when looking up courts to submit to

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1255,11 +1255,14 @@ def is_reserved_label(label, reserved_whole_words = generator_constants.RESERVED
 def remove_multiple_appearance_indicator(label):
     return re.sub(r'_{2,}\d+', '', label)
 
-def unmap(label, unmap_suffixes=generator_constants.UNMAP_SUFFIXES):
-    # map address() etc backwards
-    for suffix in unmap_suffixes:
-        if label.endswith(suffix):
-            return label.replace(suffix, unmap_suffixes[suffix])
+def unmap(label, display_to_settable=generator_constants.DISPLAY_SUFFIX_TO_SETTABLE_SUFFIX):
+    """Map attachment attributes or methods into interview order
+    attributes. For example, `.address()` will become `.address.address`"""
+    for suffix in display_to_settable:
+        match_regex = re.compile('.*' + suffix)
+        if re.match( match_regex, label ):
+            sub_regex = re.compile(suffix)
+            return re.sub( sub_regex, display_to_settable[suffix], label )
     return label
 
 def get_reserved_label_parts(prefixes:list, label:str):


### PR DESCRIPTION
Fixes #188. Test with these docs:
1. [unmap_suffixes.docx](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/5990025/unmap_suffixes.docx)
1. [unmap_suffixes.pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/5990027/unmap_suffixes.pdf)