### PR TITLE
Fix Lingering "Other" in allowed_courts causing errors in resulting interview

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -131,12 +131,12 @@ fields:
       - Other: other
   - Allowed courts: interview.allowed_courts
     datatype: checkboxes
-    none of the above: false
+    none of the above: True
     code: |
       get_court_choices() + ['Other']
   - Alternate Allowed Courts (separate with a comma): interview.allowed_courts_text
     input type: area
-    required: False
+    required: True
     show if: interview.allowed_courts['Other']
   - Categories: interview.categories
     datatype: checkboxes


### PR DESCRIPTION
* Add back None of the Above for Courts. I removed it at one point, I thought it was breaking things, but it's fine now. 
* If Other is selected for court names, make the user specified "Other" courts required. Without this change, the code that removes "Other" and replaces it with the alternate courts (https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/blob/1fa5d4fdd191369d679c8adccb3ef6a26dcbdf48/docassemble/assemblylinewizard/data/questions/assembly_line.yml#L415)  is never run. Since None of the Above is back too, I'm fine making this required. 