### PR TITLE
Added metadata to PDF pre-flight interview

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
+++ b/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
@@ -1,3 +1,7 @@
+metadata:
+  title: |
+    Assembly Line PDF Pre-flight Checker
+  short title: Pre-flight Checker
 ---
 modules:
   - .interview_generator
@@ -9,6 +13,8 @@ subquestion: |
 fields:
   - Please upload a PDF template: template_upload
     datatype: file
+    accept: |
+      ".pdf, application/pdf"
 ---
 objects:
   - placeholder_signature: DAStaticFile.using(filename='placeholder_signature.png')


### PR DESCRIPTION
Closes #259 with a super simple metadata block for the pre-flight interview.  

Also restricted upload types to PDFs only, as anything else will error right now. 