### PR TITLE
Deduplication of pdf

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -925,7 +925,7 @@ code: |
   item.field_type = 'end_attachment'
   item.variable = 'all_done'
   item.final_display_var = 'all_done'
-  item.raw_field_name = 'all_done'
+  item.raw_field_names = ['all_done']
   # item.question = end_question
   end_question.field_list.gathered = True  
   

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -337,8 +337,9 @@ code: |
   built_in_fields_used  
   
   yesno_map = defaultdict(list)
+  document_type = 'pdf' if template_upload[0].extension == 'pdf' else 'docx'
 
-  if template_upload[0].extension == 'pdf':
+  if document_type == 'pdf':
     # Probably all of this should move into a class
     for pdf_field_tuple in all_fields:
       pdf_field_name = pdf_field_tuple[0]
@@ -355,9 +356,7 @@ code: |
       # This function determines what type of variable
       # we're dealing with
       new_field.fill_in_pdf_attributes(pdf_field_tuple)
-      if not consolidate_yesnos(new_field, yesno_map):
-        del new_field
-        fields.pop()
+
   else:
     # if this is a docx, fields are a list of strings, not a list of tuples
     for field in all_fields:
@@ -368,11 +367,11 @@ code: |
       else:                
         new_field = fields.appendObject()
       new_field.fill_in_docx_attributes(field)
-    
-      if not consolidate_yesnos(new_field, yesno_map):
-        del new_field
-        fields.pop()
 
+  built_in_fields_used.consolidate_duplicate_fields(document_type)
+  signature_fields.consolidate_duplicate_fields(document_type)
+  fields.consolidate_duplicate_fields(document_type)
+  fields.consolidate_yesnos()
   get_all_fields = True
 ---
 code: |


### PR DESCRIPTION
Solves #101 .

The major thing happening in this PR is that `DAField.raw_field_name`, a single string, is turned into `DAField.raw_field_names`, a list of names of all of the PDF field names that are directly tied to this variable. Most changes are fixing all uses to use a list instead of a single string.

The other major thing is actually using these multiple field names:
* `raw_field_names()` is populated by calling `consolidate_duplicate_fields()` and `consolidate_yesnos()` on DAFieldList
* it's used in 'attachment_yaml()', where we map the backing variable back to all of it's uses in the PDF, all of the different names.

Added some extra types to strings as well