### PR TITLE
Review refactor

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -808,6 +808,7 @@ code: |
   review_block.type = "review"
   # Add the fields, removing any duplicates by assigning to a dict first
   review_block.field_list = fields + built_in_fields_used + signature_fields
+  review_block.base_var_list = review_block.field_list.collect_base_vars()
   review_block.question_text = "Review Screen"
   review_block.subquestion_text = "Edit your answers below"
   review_block.id = interview_label + ' review screen'

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -808,7 +808,7 @@ code: |
   review_block.type = "review"
   # Add the fields, removing any duplicates by assigning to a dict first
   review_block.field_list = fields + built_in_fields_used + signature_fields
-  review_block.base_var_list = review_block.field_list.collect_base_vars()
+  review_block.parent_collections = review_block.field_list.find_parent_collections()
   review_block.question_text = "Review Screen"
   review_block.subquestion_text = "Edit your answers below"
   review_block.id = interview_label + ' review screen'

--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -207,9 +207,7 @@ generator_constants.DISPLAY_SUFFIX_TO_SETTABLE_SUFFIX = {
 generator_constants.FULL_DISPLAY = {
   '\.name$': '.name.full()',
   '\.address$': '.address.block()',
-  '\.mail_address$': '.mail_address.block()',
-  '\.division$': '',  # part of the court object, need to reselect the whole thing,
-  '\.department$': ''
+  '\.mail_address$': '.mail_address.block()'
 }
 
 # Possible values for 'Allowed Courts', when looking up courts to submit to

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -941,14 +941,15 @@ class DAQuestion(DAObject):
           content += indent_by(self.question_text, 2)
           content += "subquestion: |\n"
           content += indent_by(self.subquestion_text, 2)
-          content += "review: \n"
-          reviewed_fields = set()
-          for base_var in self.base_var_list:
-              content += base_var.review_yaml(reviewed_fields)
-              content += '  - note: |\n      ------\n'
-          for base_var in self.base_var_list:
-              content += base_var.revisit_page()
-              content += base_var.table_page()
+          if len(self.base_var_list) > 0:
+            content += "review: \n"
+            reviewed_fields = set()
+            for base_var in self.base_var_list:
+                content += base_var.review_yaml(reviewed_fields)
+                content += '  - note: |\n      ------\n'
+            for base_var in self.base_var_list:
+                content += base_var.revisit_page()
+                content += base_var.table_page()
         return content
 
 class DAQuestionList(DAList):

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -544,11 +544,13 @@ columns:
 {all_columns}
 edit:
 {settable_list}
+confirm: True
 """
     all_columns = ''
     settable_list = ''
     for att, disp_and_set in self.attribute_map.items():
-      all_columns += '  - {0}: |\n      row_item.{1}\n'.format(att, disp_and_set[0])
+      all_columns += '  - {0}: |\n'.format(att)
+      all_columns += '      row_item.{0} if defined("row_item.{1}") else ""\n'.format( disp_and_set[0], disp_and_set[1])
       settable_list += '  - {}\n'.format(disp_and_set[1])
     return content.format(base_var=self.base_var_name, all_columns=all_columns, settable_list=settable_list)
 
@@ -943,6 +945,7 @@ class DAQuestion(DAObject):
           reviewed_fields = set()
           for base_var in self.base_var_list:
               content += base_var.review_yaml(reviewed_fields)
+              content += '  - note: |\n      ------\n'
           for base_var in self.base_var_list:
               content += base_var.revisit_page()
               content += base_var.table_page()

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -577,8 +577,8 @@ confirm: True
         
     if self.var_type == 'list': 
       content += indent_by(bold(self.var_name), 6) + '\n'
-      content += indent_by("% for my_var in {}:".format(self.var_name), 6)
-      content += indent_by("* ${ my_var }", 8)
+      content += indent_by("% for item in {}:".format(self.var_name), 6)
+      content += indent_by("* ${ item }", 8)
       content += indent_by("% endfor", 6)
       return content
     

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -471,7 +471,7 @@ class DAField(DAObject):
     if settable_attribute == 'address' or settable_attribute == 'mail_address':
       settable_attribute += '.address'
     plain_att = re.findall(r'([^.]*)(\..*)*', settable_attribute)[0][0]
-    full_display_att = substitute_suffix('.' + plain_att, generator_constants.FULL_DISPLAY)).lstrip('.')
+    full_display_att = substitute_suffix('.' + plain_att, generator_constants.FULL_DISPLAY).lstrip('.')
     return (plain_att, full_display_att, settable_attribute)
 
 

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1420,6 +1420,7 @@ def map_raw_to_final_display(label, document_type="pdf", reserved_whole_words=ge
     return adjusted_prefix + index # Return the pluralized standalone variable
 
   suffix = label_groups[3]
+  log('suffix for {} is: {}'.format(label, suffix), 'console')
   # Avoid transforming arbitrary suffixes into attributes
   if not suffix in reserved_suffixes_map:
     return label  # return it as is


### PR DESCRIPTION
Refactoring the review screens by adding revisit screens, which fixes quite a few issues:
Fixes #270 
Fixes #64 
Fixes #120 
Kinda address #115, not directly, but in spirit. Not sure we need to address things by screens.

Revisit screens show all of the attributes used for a specific set of objects and let you edit them (entries are blank if they aren't filled in yet).

It does that with the new class, `ParentCollection` that collects variables that all share the same "Parent variable", i.e. the same list or object variable. The ParentCollection in general outputs a much better review screen, and can spit out its own table and revisit screens if necessary.

More testing is always welcome, but it should be okay? I'll remove this line when I'm certain it's bug free.