### PR TITLE
Removed redundant generator constants

### DIFF
--- a/docassemble/assemblylinewizard/generator_constants.py
+++ b/docassemble/assemblylinewizard/generator_constants.py
@@ -20,35 +20,6 @@ generator_constants.UNDEFINED_PERSON_PREFIXES = [
   "trial_court",
 ]
 
-# Plural vars representing people
-generator_constants.PEOPLE_VARS = [
-  'users',
-  'other_parties',
-  'plaintiffs',
-  'defendants',
-  'petitioners',
-  'respondents',
-  'spouses',
-  'parents',
-  'guardians',
-  'caregivers',
-  'attorneys',
-  'translators',
-  'debt_collectors',
-  'creditors',
-  'children',
-  'guardians_ad_litem',
-  'witnesses',
-  'decedents',
-  'interested_parties',
-]  
-
-# Part of handling plural labels
-generator_constants.RESERVED_VAR_PLURALS = generator_constants.PEOPLE_VARS + [
-  'courts',
-  'docket_numbers',
-]
-
 # Prefixes as they would appear in a PDF (singular)
 generator_constants.RESERVED_PREFIXES = ["user",
   "other_party",
@@ -77,8 +48,6 @@ generator_constants.RESERVED_PREFIXES = ["user",
   "trial_court",
   ]
 
-# reserved_pluralizers_map
-
 generator_constants.RESERVED_PERSON_PLURALIZERS_MAP = {
   'user': 'users',
   'plaintiff': 'plaintiffs',
@@ -93,7 +62,7 @@ generator_constants.RESERVED_PERSON_PLURALIZERS_MAP = {
   'translator': 'translators',
   'debt_collector': 'debt_collectors',
   'creditor': 'creditors',
-  # Non-s plurals
+  # Non "s" plurals
   'other_party': 'other_parties',
   'child': 'children',
   'guardian_ad_litem': 'guardians_ad_litem',


### PR DESCRIPTION
There might be a ticket somewhere about this, but I can't find it. We have definitely discussed this in Monday meetings before though.

`PEOPLE_VARS` and `RESERVED_VARS_PLURALS` are explicitly redundant to the `RESERVED_PERSON_PLURALIZERS_MAP` and `RESERVED_PLURALIZERS_MAP` values, containing the same entries, but with less information (the latter also containing the singular versions of the words).

This PR just removes them. I tested on a docx and a PDF, which still output correctly. Things should stay exactly the same (unless some function was modifying a global... :eyes:)