### PR TITLE
296 add version number

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -455,6 +455,7 @@ code: |
   metadata_code = interview.blocks.appendObject()
   metadata_code.template_key = "al metadata"
   metadata_code.data = {
+    "al_weaver_version": package_version_number,
     "interview_label": interview_label,
     "title": interview.title,
     "short_title": interview.short_title,

--- a/docassemble/assemblylinewizard/data/sources/output_patterns.yml
+++ b/docassemble/assemblylinewizard/data/sources/output_patterns.yml
@@ -190,6 +190,9 @@ al metadata: |
     if not defined("interview_metadata['${ interview_label }']"):
       interview_metadata.initializeObject("${ interview_label }")
       interview_metadata["${ interview_label }"].update({
+        % if al_weaver_version:
+        "al_weaver_version": "${ al_weaver_version }",
+        % endif
         "title": "${ escape_quotes(oneline(title)) }",
         "short title": "${ escape_quotes(oneline(short_title)) }",
         "description": "${ escape_quotes(oneline(description)) }",

--- a/docassemble/assemblylinewizard/data/sources/output_patterns.yml
+++ b/docassemble/assemblylinewizard/data/sources/output_patterns.yml
@@ -13,7 +13,8 @@
 mako template local imports:
   interview_generator: [fix_id, varname, mako_indent, using_string, escape_quotes, oneline]
 # To import from an installed package or third-party Python package, provide a list of strings
-#mako template imports: 
+mako template imports: 
+  - from docassemble.base.util import today
 #  - from docassemble.assemblylinewizard.interview_generator import fix_id, varname, mako_indent, using_string, escape_quotes, oneline
 # Ordinary question with or without fields
 question: |
@@ -193,6 +194,7 @@ al metadata: |
         % if al_weaver_version:
         "al_weaver_version": "${ al_weaver_version }",
         % endif
+        "generated on": "${ today().format("yyyy-MM-dd") }",
         "title": "${ escape_quotes(oneline(title)) }",
         "short title": "${ escape_quotes(oneline(short_title)) }",
         "description": "${ escape_quotes(oneline(description)) }",


### PR DESCRIPTION
fix #296

Add date of generation and version number of weaver, if available, to the form-specific metadata. If the weaver is run from the playground (which you may do in your review) it will display "playground" as the version number as it has no accurate way to access anything more specific.