### PR TITLE
Fixes #346, stop including numbers and courts as people.

### DIFF
--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -1189,7 +1189,7 @@ def get_person_variables(fieldslist,
   if custom_only:
     return people - set(reserved_pluralizers_map.values())
   else:
-    return people
+    return people - (set(reserved_pluralizers_map.values()) - set(people_vars))
 
 def set_custom_people_map( people_var_names ):
   """Sets the map of custom people created by the developer."""


### PR DESCRIPTION
When fixing #286 by removing non-people object from custom people, I introduced an issue where custom people (now not including non-people like docket numbers, etc.) were removed from non-custom people (which did still include non-people objects), leaving the non-people objects still!

Now, non-people objects are removed from both. 