### PR TITLE
Dependencies in generated interviews

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -1163,8 +1163,7 @@ code: |
 ---
 event: install_package_event
 code: |
-  data = {"key": install_packages_api_key,
-          "restart": 0
+  data = {"key": install_packages_api_key
           }
   files = {'zip': interview_package_download }
   status = installer.post("package",data=data, files=files, task='install package')  

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -167,6 +167,20 @@ help:
 
     ${fields}
 ---
+id: dependency question
+question: Which jurisdictions and organizations is this form a part of?
+subquestion: |
+  New jurisdictions will be added soon. You should add those dependencies manually in the Playground until then.
+fields:
+  - no label: interview.dependency_choices
+    datatype: checkboxes
+    choices:
+      - Massachusetts: docassemble.ALMassachusetts>=0.0.7
+      - MassAccess: docassemble.MassAccess
+    default:
+      - docassemble.ALMassachusetts>=0.0.7
+      - docassemble.MassAccess
+---
 code: |
   if interview.form_type == 'starts_case':
     interview_intro_prompt_default = "Ask the court for a " + interview.short_title
@@ -967,9 +981,9 @@ code: |
     "sources": []
   }
   
-  create_package_zip(package_title, 
-        interview.package_info(), 
-        {"author name and email":"author@example.com"}, 
+  create_package_zip(package_title,
+        interview.package_info(interview.dependency_choices.true_values()),
+        {"author name and email":"author@example.com"},
         folders_and_files, 
         interview_package_download)
 

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -170,12 +170,17 @@ help:
 id: dependency question
 question: Which jurisdictions and organizations is this form a part of?
 subquestion: |
-  New jurisdictions will be added soon. You should add those dependencies manually in the Playground until then.
+  This will add those jurisdictions as dependencies. If you are unsure, leave the default options checked.
+help:
+  label: My jurisdiction is not here
+  content: |
+    New jurisdictions will be added soon. You should add those dependencies manually in the Playground until then.
 fields:
   - no label: interview.dependency_choices
     datatype: checkboxes
+    required: False
     choices:
-      - Massachusetts: docassemble.ALMassachusetts>=0.0.7
+      - Massachusetts State: docassemble.ALMassachusetts>=0.0.7
       - MassAccess: docassemble.MassAccess
     default:
       - docassemble.ALMassachusetts>=0.0.7

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -154,10 +154,13 @@ class DAInterview(DAObject):
         super().init(*pargs, **kwargs)
         self.blocks = DABlockList(auto_gather=False, gathered=True, is_mandatory=False)
         self.questions = DAQuestionList(auto_gather=False, gathered=True, is_mandatory=False)
-        
+
     def package_info(self, dependencies:List[str]=None) -> Dict[str, Any]:
+        assembly_line_dep = 'docassemble.AssemblyLine'
         if dependencies is None:
-          dependencies = ['docassemble.AssemblyLine', 'docassemble.ALMassachusetts', 'docassemble.MassAccess']
+            dependencies = [assembly_line_dep, 'docassemble.ALMassachusetts', 'docassemble.MassAccess']
+        elif assembly_line_dep not in dependencies:
+            dependencies.append(assembly_line_dep)
 
         info = dict()
         for field in ['interview_files', 'template_files', 'module_files', 'static_files']:

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -13,7 +13,7 @@ from docassemble.base.core import DAEmpty
 import datetime
 import zipfile
 import json
-from typing import Dict, List, Tuple #, Set
+from typing import Any, Dict, List, Tuple #, Set
 from .generator_constants import generator_constants
 from .custom_values import custom_values
 import ruamel.yaml as yaml
@@ -155,11 +155,15 @@ class DAInterview(DAObject):
         self.blocks = DABlockList(auto_gather=False, gathered=True, is_mandatory=False)
         self.questions = DAQuestionList(auto_gather=False, gathered=True, is_mandatory=False)
         
-    def package_info(self)->dict:
+    def package_info(self, dependencies:List[str]=None) -> Dict[str, Any]:
+        if dependencies is None:
+          dependencies = ['docassemble.AssemblyLine', 'docassemble.ALMassachusetts', 'docassemble.MassAccess']
+
         info = dict()
-        for field in ['dependencies', 'interview_files', 'template_files', 'module_files', 'static_files']:
+        for field in ['interview_files', 'template_files', 'module_files', 'static_files']:
             if field not in info:
                 info[field] = list()
+        info['dependencies'] = dependencies
         info['author_name'] = ""                
         info['readme'] = ""
         info['description'] = self.title
@@ -1261,7 +1265,7 @@ def create_package_zip(pkgname: str, info: dict, author_info: dict, folders_and_
   zip_download.initialize(filename="docassemble-" + pkgname + ".zip")
   zip_obj = zipfile.ZipFile(zip_download.path(),'w')
 
-  dependencies = ",".join(info['dependencies'])
+  dependencies = ",".join(['\'' + dep + '\'' for dep in info['dependencies']])
 
   initpy = """\
 try:


### PR DESCRIPTION
Closes https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/issues/322, although more work is needed to incorporate more jurisdictions (#149).

Adds a separate screen to select the packages to include. It could be shoved into another screen, but would be much less understandable. Made the screen have good defaults, so we should be able to just continue 99% of the time.