### PR TITLE
Stop on invalid names

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -318,10 +318,14 @@ code: |
   if template_upload[0].extension == 'pdf':
     all_fields = get_pdf_fields(template_upload)
   else:
-    all_fields = get_fields(template_upload) # template_upload.get_docx_variables()
+    all_fields = get_fields(template_upload)
 
   if all_fields is None:
     force_ask('empty_pdf')
+
+  bad_fields = list(filter(lambda elem: elem is not None, map(bad_name_reason, all_fields)))
+  if len(bad_fields) > 0:
+    force_ask('non_descriptive_field_name')
 ---
 event: empty_pdf
 question: You uploaded an empty PDF
@@ -331,6 +335,20 @@ subquestion: |
   
   If you saved a DOCX file as a PDF, you will need to add fillable fields in a tool like [Adobe Acrobat](https://acrobat.adobe.com). 
   For more info, see the [documentation](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs).
+
+buttons:
+  - Restart: restart
+---
+event: non_descriptive_field_name
+question: Some of the fields in your PDF are not descriptive
+subquestion: |
+  There are fields that can't be turned into descriptive variable names in the given PDF. You should make sure all field names abide by the rules in the [documentation](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs).
+  
+  The fields that have issues are:
+
+  % for bad_field in bad_fields:
+    * ${ bad_field }
+  % endfor
 
 buttons:
   - Restart: restart

--- a/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
+++ b/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
@@ -44,7 +44,7 @@ code: |
   for field in fields:
     if ' ' in field[0]:
       warnings_temp.add('space')
-    if len(remove_multiple_indicator(varname(field[0]))) == 0:
+    if len(remove_multiple_appearance_indicator(varname(field[0]))) == 0:
       warnings_temp.add('invalid_name')
     if field[4] not in ['/Sig','/Btn','/Tx']:
       warnings_temp.add('not handled')
@@ -55,15 +55,10 @@ question: |
   Field list
 subquestion: |
 
-  Field name (bold if {reserved}) | Field type | {Internal docassemble name} | Max length
+  Field name (bold if {reserved}) | Field type | {Internal DA name} | Max length
   -----------|------------|-------------------|-----------
   % for field in fields:
-  ${":exclamation-triangle: " if ' ' in field[0] else ''}
-  ${":exclamation-square: " if len(remove_multiple_indicator(varname(field[0]))) == 0 else ''}
-  ${'**' + str(field[0]) + '**' if is_reserved_label(field[0]) else field[0]} | 
-  ${ pdf_field_type_str(field) } (${field[4]}) |
-  ${map_raw_to_final_display(field[0]) if not (map_raw_to_final_display(field[0]) == field[0]) else ''} | 
-  ${ get_character_limit(field) if get_character_limit(field) else 'n/a' }
+  ${":exclamation-triangle: " if ' ' in field[0] else ''} ${":exclamation-circle: " if len(remove_multiple_appearance_indicator(varname(field[0]))) == 0 else ''} ${'**' + str(field[0]) + '**' if is_reserved_label(field[0]) else field[0]} | ${ pdf_field_type_str(field) } (${field[4]}) | ${map_raw_to_final_display(field[0]) if not (map_raw_to_final_display(field[0]) == field[0]) else ''} | ${ get_character_limit(field) if get_character_limit(field) else 'n/a' }
   % endfor
 
   The following are signature fields: ${comma_and_list(signature_fields)} 
@@ -87,7 +82,7 @@ subquestion: |
   % endif
 
   % if 'invalid_name' in warnings:
-  :exclamation_square: indicates that a field name is not a valid variable name.
+  :exclamation-circle: indicates that a field name is not a valid variable name.
   At the least, start the field name with an alphabetical character (a-z).
   % endif
   
@@ -111,7 +106,7 @@ help: |
 terms: 
   - reserved: |
       Means there is a built-in question for this field.
-  - Internal docassemble name: |
+  - Internal DA name: |
       Means that the variable name will be changed for Docassemble. 
       We change names that have built-in questions, as well as those starting
       with the name of a person/group of people, which we turn into "attributes" of that person.

--- a/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
+++ b/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
@@ -11,7 +11,7 @@ question: |
 subquestion: |
   Use this tool to validate your PDF once you have labeled all fields.
 fields:
-  - Please upload a PDF template: template_upload
+  - Upload a PDF template: template_upload
     datatype: file
     accept: |
       ".pdf, application/pdf"
@@ -39,31 +39,15 @@ subquestion: |
 buttons:
   - Restart: restart
 ---
-comment: |
-  This block was copied from assembly_line.yml
-  
-  Please update it if the assembly_line.yml is updated.
-variable name: variables_to_skip
-data:
-  - signature_date
-  - plaintiff
-  - plaintiffs
-  - defendant
-  - defendants
-  - petitioner
-  - petitioners
-  - witnesses
-  - users
-  - other_parties
-  - children
----
 code: |
   warnings_temp = set()
   for field in fields:
     if ' ' in field[0]:
       warnings_temp.add('space')
+    if len(remove_multiple_indicator(varname(field[0]))) == 0:
+      warnings_temp.add('invalid_name')
     if field[4] not in ['/Sig','/Btn','/Tx']:
-      'not handled'
+      warnings_temp.add('not handled')
   warnings = warnings_temp
   del warnings_temp
 ---
@@ -74,7 +58,12 @@ subquestion: |
   Field name (bold if {reserved}) | Field type | {Internal docassemble name} | Max length
   -----------|------------|-------------------|-----------
   % for field in fields:
-  ${ ":exclamation-triangle: " if ' ' in field[0] else ''}${'**' + str(field[0]) + '**' if is_reserved_label(field[0]) else field[0]} | ${'Signature' if field[4] == '/Sig' else 'Checkbox' if field[4] == '/Btn' else "Text" if field[4] == '/Tx' else ':skull-crossbones:'} (${field[4]}) | ${map_raw_to_final_display(field[0]) if is_reserved_label(field[0]) else ''} | ${ get_character_limit(field) if get_character_limit(field) else 'n/a' }
+  ${":exclamation-triangle: " if ' ' in field[0] else ''}
+  ${":exclamation-square: " if len(remove_multiple_indicator(varname(field[0]))) == 0 else ''}
+  ${'**' + str(field[0]) + '**' if is_reserved_label(field[0]) else field[0]} | 
+  ${ pdf_field_type_str(field) } (${field[4]}) |
+  ${map_raw_to_final_display(field[0]) if not (map_raw_to_final_display(field[0]) == field[0]) else ''} | 
+  ${ get_character_limit(field) if get_character_limit(field) else 'n/a' }
   % endfor
 
   The following are signature fields: ${comma_and_list(signature_fields)} 
@@ -86,21 +75,26 @@ subquestion: |
   to be bold, check spelling.
   
   Names for groups of **people** should be bold if you followed our naming guidelines.
-  Please make sure that you used the right name. E.g., use "plaintiff" not
+  Make sure that you used the right name. E.g., use "plaintiff" not
   "plaintiff_tenant". Check for misspellings if a name is not bold.
   
   Let us know if we should add a new type of person.
   
   % if 'space' in warnings:
-  :exclamation-triangle: Indicates that the field name has a space in it. Please
-  replace any spaces with underscores in the PDF field name before uploading to 
+  :exclamation-triangle: Indicates that the field name has a space in it.
+  Replace any spaces with underscores in the PDF field name before uploading to
   Trello.
+  % endif
+
+  % if 'invalid_name' in warnings:
+  :exclamation_square: indicates that a field name is not a valid variable name.
+  At the least, start the field name with an alphabetical character (a-z).
   % endif
   
   % if 'not handled' in warnings:
   :skull-crossbones: Indicates it's a field type that our interview generator
   does not currently handle. OR that the field has a duplicate name. 
-  Please make sure the field is a checkbox, text 
+  Make sure the field is a checkbox, text
   input, or digital signature field and that it is not a duplicate.
   % endif
   
@@ -134,10 +128,10 @@ question: |
 subquestion: |
   The fields are filled in with the name that we'll use in the YAML file.
   
-  All checkboxes should be checked. If not, please check the field's
+  All checkboxes should be checked. If not, check the field's
   "export" value. It should be set to "Yes".
   
-  If the text is unusually sized, then please check the font size and 
+  If the text is unusually sized, then check the font size and
   whether the field is set to allow multiple lines.
   
   All signature fields should be filled in with this image: ${placeholder_signature}

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -31,7 +31,7 @@ __all__ = ['indent_by', 'varname', 'DAField', 'DAFieldList', \
            'base_name', 'escape_quotes', 'oneline', 'DAQuestionList', 'map_raw_to_final_display', \
            'is_reserved_label', 'attachment_download_html', \
            'get_fields', 'get_pdf_fields', 'is_reserved_docx_label','get_character_limit', \
-           'create_package_zip', \
+           'create_package_zip', 'remove_multiple_appearance_indicator', \
            'get_person_variables', 'get_court_choices',\
            'process_custom_people', 'set_custom_people_map',\
            'map_names','fix_id','DABlock', 'DABlockList','mako_indent',\


### PR DESCRIPTION
Fixes #261 by immediately stopping the weaver on PDFs that have variables that we can't turn into valid python identifiers. Started trying to check if we could check for invalid python in DOCX, but that would take a bit more refactoring, so I left that as a TODO.

Also added the check to the preflight tool, and cleaned that up a bit.