### PR TITLE
No more 0 indexing 300

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -313,19 +313,27 @@ help:
 continue button field: ask_people_quantity_question  
 ---
 comment: |
-  Get the list of fields
+  Get the list of fields, and check for any possible labeling errors
+  right away
 code: |
-  if template_upload[0].extension == 'pdf':
-    all_fields = get_pdf_fields(template_upload)
-  else:
-    all_fields = get_fields(template_upload)
+  try:
+    if template_upload[0].extension == 'pdf':
+      all_fields = get_pdf_fields(template_upload)
+    else:
+      all_fields = get_fields(template_upload)
+      
+    if all_fields is None:
+      force_ask('empty_pdf')
 
-  if all_fields is None:
-    force_ask('empty_pdf')
-
-  bad_fields = list(filter(lambda elem: elem is not None, map(bad_name_reason, all_fields)))
-  if len(bad_fields) > 0:
-    force_ask('non_descriptive_field_name')
+    bad_fields = list(filter(
+        lambda elem: elem is not None, 
+        map(bad_name_reason, all_fields)))
+    if len(bad_fields) > 0:
+      force_ask('non_descriptive_field_name')
+      
+  except ParsingException as ex:
+    parsing_ex = ex
+    force_ask('parsing_exception')
 ---
 event: empty_pdf
 question: You uploaded an empty PDF
@@ -350,6 +358,18 @@ subquestion: |
     * ${ bad_field }
   % endfor
 
+buttons:
+  - Restart: restart
+---
+event: parsing_exception
+question: ${ parsing_ex.main_issue }
+subquestion: |
+  ${ parsing_ex.description }
+
+  % if parsing_ex.url is not None:
+  Check out the [documentation](${ parsing_ex.url }) to learn more.
+  % endif
+  
 buttons:
   - Restart: restart
 ---

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -963,15 +963,14 @@ def map_raw_to_final_display(label:str, document_type:str="pdf",
   # of the plural version of the prefix of the label
   if (adjusted_prefix in reserved_pluralizers_map.values()
       or adjusted_prefix in custom_people_plurals_map.values()):
-    maybe_digit = label_groups[2]
-    if maybe_digit == '':
-      digit = ''
+    digit_str = label_groups[2]
+    if digit_str == '':
       index = '[0]'
     else:
       try:
-        digit = int(maybe_digit)
+        digit = int(digit_str)
       except ValueError as ex:
-        raise ParsingException('{} is not a digit'.format(maybe_digit),
+        raise ParsingException('{} is not a digit'.format(digit_str),
             'Full issue: {}. This is likely a developer error! ' + \
             'Please [let us know](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/issues/new)!'.format(ex))
 
@@ -982,14 +981,14 @@ def map_raw_to_final_display(label:str, document_type:str="pdf",
         url = "https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/label_variables#more-than-one"
         raise ParsingException(main_issue, err_str, url)
       else:
-        index = '[' + str(int(digit)-1) + ']'
+        index = '[' + str(digit - 1) + ']'
   else:
-    digit = ''
+    digit_str = ''
     index = ''
   
   # it's just a standalone, like "defendant", or it's a numbered singular
   # prefix, e.g. user3
-  if label == prefix or label == prefix + digit:
+  if label == prefix or label == prefix + digit_str:
     return adjusted_prefix + index # Return the pluralized standalone variable
 
   suffix = label_groups[3]

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -34,7 +34,7 @@ __all__ = ['ParsingException', 'indent_by', 'varname', 'DAField', 'DAFieldList',
            'create_package_zip', 'remove_multiple_appearance_indicator', \
            'get_person_variables', 'get_court_choices',\
            'process_custom_people', 'set_custom_people_map',\
-           'map_names','fix_id','DABlock', 'DABlockList','mako_indent',\
+           'fix_id','DABlock', 'DABlockList','mako_indent',\
            'using_string', 'pdf_field_type_str', \
            'bad_name_reason', 'mako_local_import_str']
 
@@ -905,21 +905,6 @@ def get_docx_variables( text:str )->set:
 ########################################################
 # Map names code
 
-# TODO: map_names is deprecated but old code depends on it. This is temporary shim
-def map_names(label, document_type="pdf", reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
-              custom_people_plurals_map=custom_values.people_plurals_map,
-              reserved_prefixes=generator_constants.RESERVED_PREFIXES,
-              undefined_person_prefixes=generator_constants.UNDEFINED_PERSON_PREFIXES,
-              reserved_pluralizers_map = generator_constants.RESERVED_PLURALIZERS_MAP,
-              reserved_suffixes_map=generator_constants.RESERVED_SUFFIXES_MAP):
-  return map_raw_to_final_display(label, document_type=document_type,
-              reserved_whole_words=reserved_whole_words,
-              custom_people_plurals_map=custom_people_plurals_map,
-              reserved_prefixes=reserved_prefixes,
-              undefined_person_prefixes=undefined_person_prefixes,
-              reserved_pluralizers_map = reserved_pluralizers_map,
-              reserved_suffixes_map=reserved_suffixes_map)
-  
 def map_raw_to_final_display(label:str, document_type:str="pdf",
               reserved_whole_words=generator_constants.RESERVED_WHOLE_WORDS,
               custom_people_plurals_map=custom_values.people_plurals_map,


### PR DESCRIPTION
Just stops people from 0 indexing lists of people in PDFs. Should be consistent and stick with 1 indexing.

Due to some refactoring of `map_raw_to_final_display` (i.e. `map_names`), this depends on https://github.com/SuffolkLITLab/docassemble-MAVirtualCourt/issues/603 (branch in progress) and should be merged after so it doesn't break any MAVC interviews.