### PR TITLE
Allow custom attributes on custom people objects

### DIFF
--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -445,11 +445,6 @@ class DAField(DAObject):
     """Turn the docassemble variable string into an expression
     that makes DA ask a question for it. This is mostly
     calling `gather()` for lists"""
-    # TODO: we might want to think about how to handle the custom names differently
-    # in the future. This lets us avoid having to specify the full/combined list of people
-    # exact prefix matches are dealt with easily
-    if hasattr(self, 'custom_trigger_gather'):
-      return self.custom_trigger_gather
     GATHER_CALL = '.gather()'
     if self.final_display_var in reserved_whole_words:
       return self.final_display_var
@@ -1083,9 +1078,6 @@ def process_custom_people(custom_people:list, fields:list, built_in_fields:list,
     # If it's not already a DOCX-like variable and the new mapped name doesn't match old name
     if not ('[' in field.variable) and new_potential_name != field.variable:
       field.final_display_var = new_potential_name
-      for person in custom_people:
-        if field.final_display_var.startswith(person + "["):
-          field.custom_trigger_gather = person + ".gather()"
       fields_to_add.add(field)
       delete_list.append(field) # Cannot mutate in place
     else:
@@ -1093,9 +1085,6 @@ def process_custom_people(custom_people:list, fields:list, built_in_fields:list,
       matching_docx_test = r"^(" + "|".join(custom_people) + ")\[\d+\](" + ("|".join([suffix.replace(".","\.") for suffix in people_suffixes])) + ")$"
       log(matching_docx_test)
       if re.match(matching_docx_test, field.variable):
-        for person in custom_people:
-          if field.final_display_var.startswith(person + "["):
-            field.custom_trigger_gather = person + ".gather()"
         delete_list.append(field)
         fields_to_add.add(field)
 


### PR DESCRIPTION
Stopped using custom_trigger_gather, it just works :tm:. Fixes #366. Tested with 
[dta_employment_info.pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/6503439/dta_employment_info.pdf).

When this was first [implemented](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/commit/f3a410be0169ae3c75c065349bbb811b26d25a13#), we weren't passing custom people to `trigger_gather()`.  After https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/commit/45b0735ff3861e2c86f2c7e6bdcaedc108db7b9d we are, so the original implementation isn't needed.

Potential downside: only the specific PDF label referenced is triggered. I.e. `employee1_address_address` only asks for `employee[0].address.address`, and not `employee[1].address.address`. Works for the form, but might be confusing behavior. 

Might be the first time I've ever added a feature only by removing code :sunglasses: 