### PR TITLE
Don't display "send editable" on pdfs

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -1042,7 +1042,10 @@ need:
 code: |
   end_question = interview.blocks.appendObject()
   end_question.template_key = 'download screen'
-  end_question.data = {"interview_label": interview_label}
+  end_question.data = {
+      "interview_label": interview_label, 
+      "document_type": 'pdf' if any(map(lambda templ: templ.extension == 'pdf', template_upload)) else 'docx'
+  }
   add_end_question = True
 ---  
 code: |

--- a/docassemble/assemblylinewizard/data/sources/output_patterns.yml
+++ b/docassemble/assemblylinewizard/data/sources/output_patterns.yml
@@ -90,9 +90,10 @@ download screen: |
     ${ action_button_html(url_action('review_" + interview_label + "'), label='Make changes', color='info') }
 
     ${ al_user_bundle.download_list_html() }
-
-    ${ al_user_bundle.send_button_html() }
     </%text>
+
+    \$\{ al_user_bundle.send_button_html(send_editable_checkbox=${document_type == 'pdf'}) \}
+
   progress: 100
 # Code block
 code: |

--- a/docassemble/assemblylinewizard/data/sources/output_patterns.yml
+++ b/docassemble/assemblylinewizard/data/sources/output_patterns.yml
@@ -92,7 +92,7 @@ download screen: |
     ${ al_user_bundle.download_list_html() }
     </%text>
 
-    \$\{ al_user_bundle.send_button_html(send_editable_checkbox=${document_type == 'pdf'}) \}
+    <%text>${</%text> al_user_bundle.send_button_html(show_editable_checkbox=${document_type != 'pdf'}) <%text>}</%text>
 
   progress: 100
 # Code block


### PR DESCRIPTION
Fixes #354. Tested on a PDF and DOCX, though I had to modify them for alternate reasons (seems I only have bug-trigger testing docs on hand and nothing that really works).