### PR TITLE
Actually include selected packages

### DIFF
--- a/docassemble/assemblylinewizard/custom_values.py
+++ b/docassemble/assemblylinewizard/custom_values.py
@@ -7,6 +7,10 @@ from docassemble.base.util import DADict
 Container for widely used data that may be altered by user inputs.
 """
 
+__all__ = ['get_possible_dependencies', 'get_pypi_deps_from_choices', 'get_yml_deps_from_choices', 
+           'get_is_default_from_choices']
+
+
 # This is to workaround fact you can't do local import in Docassemble playground
 class Object(object):
   pass
@@ -50,23 +54,23 @@ def load_org_specific(all_custom_values=custom_values):
 def get_possible_dependencies(all_custom_values=custom_values):
   """Gets the possible yml files that the generated interview will depend on"""
   load_org_specific(all_custom_values)
-  return all_custom_values['dependency_choices'].keys()
+  return all_custom_values.org_specific_config['dependency_choices'].keys()
 
 
 def get_pypi_deps_from_choices(choices:Union[List[str], DADict], 
     all_custom_values=custom_values):
-  return get_value_from_choices(choices, 0)
+  return get_values_from_choices(choices, 0)
 
-def get_yml_dep_from_choices(choices:Union[List[str], DADict], 
+def get_yml_deps_from_choices(choices:Union[List[str], DADict], 
     all_custom_values=custom_values):
-  return get_value_from_choices(choices, 1)
+  return get_values_from_choices(choices, 1)
 
 def get_is_default_from_choices(all_custom_values=custom_values):
   load_org_specific(all_custom_values)
   return [dependency[0] for dependency in 
-      all_custom_values['dependency_choices'].items() if dependency[1][2]] 
+      all_custom_values.org_specific_config['dependency_choices'].items() if dependency[1][2]] 
 
-def get_value_from_choices(choices:Union[List[str], DADict], value_idx:int=0,
+def get_values_from_choices(choices:Union[List[str], DADict], value_idx:int=0,
     all_custom_values=custom_values):
   load_org_specific(all_custom_values)
   if isinstance(choices, DADict):
@@ -74,5 +78,5 @@ def get_value_from_choices(choices:Union[List[str], DADict], value_idx:int=0,
   else: # List
     choice_list = choices
   
-  return [all_custom_values['dependency_choices'][chosen_val][value_idx] 
+  return [all_custom_values.org_specific_config['dependency_choices'][chosen_val][value_idx] 
       for chosen_val in choice_list] 

--- a/docassemble/assemblylinewizard/custom_values.py
+++ b/docassemble/assemblylinewizard/custom_values.py
@@ -1,3 +1,8 @@
+from typing import List, Union
+from pathlib import Path
+import json
+from docassemble.base.util import DADict
+
 """
 Container for widely used data that may be altered by user inputs.
 """
@@ -12,3 +17,62 @@ custom_values = Object()
 # Could be a list, but a dict will match RESERVED_PLURALIZERS_MAP in the
 # places it's used, so maybe easier to treat them both the same.
 custom_values.people_plurals_map = {}
+
+
+# Filled in by load_org_specific. Is a dictionary of configs that each org using
+# the Weaver can set, per installation. The specific configs are:
+# * dependency choices: a collection of other yaml files that the generated interview will include
+#   It's a map from keys, what the user will see when selecting dependencies, that maps to
+#   a list of 3 items: the pypi dependency, the yaml include, and a boolean for default selection
+custom_values.org_specific_config = None
+
+def load_org_specific(all_custom_values=custom_values):
+  if all_custom_values.org_specific_config is None:
+    current_dir = Path(__file__).resolve().parent
+    config_file = current_dir.joinpath('data/sources/org_specific.cfg')
+    if config_file.exists():
+      all_custom_values.org_specific_config = json.load(config_file.open())
+    else:
+      # Populate some default values
+      all_custom_values.org_specific_config = {
+        'dependency_choices': {
+          'Massachusetts State': 
+              ['docassemble.ALMassachusetts>=0.0.7', 
+               'docassemble.ALMassachusetts:al_massachusetts.yml', 
+               True],
+          'MassAccess': 
+              ['docassemble.MassAccess',  
+               'docassemble.MassAccess:massaccess.yml', 
+               True]
+        }
+      }
+
+def get_possible_dependencies(all_custom_values=custom_values):
+  """Gets the possible yml files that the generated interview will depend on"""
+  load_org_specific(all_custom_values)
+  return all_custom_values['dependency_choices'].keys()
+
+
+def get_pypi_deps_from_choices(choices:Union[List[str], DADict], 
+    all_custom_values=custom_values):
+  return get_value_from_choices(choices, 0)
+
+def get_yml_dep_from_choices(choices:Union[List[str], DADict], 
+    all_custom_values=custom_values):
+  return get_value_from_choices(choices, 1)
+
+def get_is_default_from_choices(all_custom_values=custom_values):
+  load_org_specific(all_custom_values)
+  return [dependency[0] for dependency in 
+      all_custom_values['dependency_choices'].items() if dependency[1][2]] 
+
+def get_value_from_choices(choices:Union[List[str], DADict], value_idx:int=0,
+    all_custom_values=custom_values):
+  load_org_specific(all_custom_values)
+  if isinstance(choices, DADict):
+    choice_list = choices.true_values()
+  else: # List
+    choice_list = choices
+  
+  return [all_custom_values['dependency_choices'][chosen_val][value_idx] 
+      for chosen_val in choice_list] 

--- a/docassemble/assemblylinewizard/custom_values.py
+++ b/docassemble/assemblylinewizard/custom_values.py
@@ -1,15 +1,15 @@
 from typing import List, Union
 from pathlib import Path
-import json
-from docassemble.base.util import DADict
+import yaml
+from docassemble.base.util import log, DADict
+from docassemble.base.core import objects_from_file
 
 """
 Container for widely used data that may be altered by user inputs.
 """
 
-__all__ = ['get_possible_dependencies', 'get_pypi_deps_from_choices', 'get_yml_deps_from_choices', 
-           'get_is_default_from_choices']
-
+__all__ = ['get_possible_deps_as_choices', 'get_pypi_deps_from_choices', 
+           'get_yml_deps_from_choices']
 
 # This is to workaround fact you can't do local import in Docassemble playground
 class Object(object):
@@ -22,53 +22,56 @@ custom_values = Object()
 # places it's used, so maybe easier to treat them both the same.
 custom_values.people_plurals_map = {}
 
-
 # Filled in by load_org_specific. Is a dictionary of configs that each org using
 # the Weaver can set, per installation. The specific configs are:
-# * dependency choices: a collection of other yaml files that the generated interview will include
+# * jurisdiction_dependency_choices: a collection of other yaml files 
+#   that the generated interview will include, specifically a jurisdiction
 #   It's a map from keys, what the user will see when selecting dependencies, that maps to
 #   a list of 3 items: the pypi dependency, the yaml include, and a boolean for default selection
 custom_values.org_specific_config = None
 
 def load_org_specific(all_custom_values=custom_values):
   if all_custom_values.org_specific_config is None:
-    current_dir = Path(__file__).resolve().parent
-    config_file = current_dir.joinpath('data/sources/org_specific.cfg')
-    if config_file.exists():
-      all_custom_values.org_specific_config = json.load(config_file.open())
-    else:
+    try:
+      all_custom_values.org_specific_config = objects_from_file('org_specific.yml')
+    except SystemError as ex:
       # Populate some default values
       all_custom_values.org_specific_config = {
         'dependency_choices': {
           'Massachusetts State': 
               ['docassemble.ALMassachusetts>=0.0.7', 
-               'docassemble.ALMassachusetts:al_massachusetts.yml', 
+               'docassemble.ALMassachusetts:al_massachusetts.yml',
+               'jurisdiction',
                True],
           'MassAccess': 
               ['docassemble.MassAccess',  
-               'docassemble.MassAccess:massaccess.yml', 
+               'docassemble.MassAccess:massaccess.yml',
+               'organization',
                True]
         }
       }
 
-def get_possible_dependencies(all_custom_values=custom_values):
+def get_possible_deps_as_choices(dep_category=None, all_custom=custom_values):
   """Gets the possible yml files that the generated interview will depend on"""
-  load_org_specific(all_custom_values)
-  return all_custom_values.org_specific_config['dependency_choices'].keys()
+  load_org_specific(all_custom)
+  dep_choices = all_custom.org_specific_config['dependency_choices']
+  if dep_category is None:
+    return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items()]
+  else:
+    return [{dep_key: dep_key, 'default': dep[3]} for dep_key, dep in dep_choices.items() 
+            if dep[2].lower() == dep_category.lower()]
 
-
-def get_pypi_deps_from_choices(choices:Union[List[str], DADict], 
-    all_custom_values=custom_values):
+def get_pypi_deps_from_choices(choices:Union[List[str], DADict],
+    all_custom=custom_values):
+  """Gets the Pypi dependency requirement (i.e. docassemble.AssemblyLine>=2.0.19)
+  from some chosen dependencies"""
   return get_values_from_choices(choices, 0)
 
-def get_yml_deps_from_choices(choices:Union[List[str], DADict], 
+def get_yml_deps_from_choices(choices:Union[List[str], DADict],
     all_custom_values=custom_values):
+  """Gets the yml file (i.e. docassemble.AssemblyLine:data/question/ql_baseline.yml)
+  from some chosen dependencies"""
   return get_values_from_choices(choices, 1)
-
-def get_is_default_from_choices(all_custom_values=custom_values):
-  load_org_specific(all_custom_values)
-  return [dependency[0] for dependency in 
-      all_custom_values.org_specific_config['dependency_choices'].items() if dependency[1][2]] 
 
 def get_values_from_choices(choices:Union[List[str], DADict], value_idx:int=0,
     all_custom_values=custom_values):

--- a/docassemble/assemblylinewizard/custom_values.py
+++ b/docassemble/assemblylinewizard/custom_values.py
@@ -3,6 +3,9 @@ from pathlib import Path
 import yaml
 from docassemble.base.util import log, DADict
 from docassemble.base.core import objects_from_file
+# TODO(brycew): is this too deep into DA? Unclear if there are options to write
+# sources files to a package while it's running.
+from docassemble.base.functions import package_data_filename
 
 """
 Container for widely used data that may be altered by user inputs.
@@ -34,7 +37,7 @@ def load_org_specific(all_custom_values=custom_values):
   if all_custom_values.org_specific_config is None:
     try:
       all_custom_values.org_specific_config = objects_from_file('org_specific.yml')
-    except SystemError as ex:
+    except (FileNotFoundError, SystemError) as ex:
       # Populate some default values
       all_custom_values.org_specific_config = {
         'dependency_choices': {
@@ -50,6 +53,9 @@ def load_org_specific(all_custom_values=custom_values):
                True]
         }
       }
+      to_write = package_data_filename('data/sources/org_specific.yml')
+      with open(to_write, 'w') as writ:
+        writ.write(yaml.safe_dump(all_custom_values.org_specific_config))
 
 def get_possible_deps_as_choices(dep_category=None, all_custom=custom_values):
   """Gets the possible yml files that the generated interview will depend on"""

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -203,8 +203,11 @@ fields:
   - no label: interview.dependency_choices
     datatype: checkboxes
     required: False
-    code:
-      get_possible_dependencies()
+    code: |
+      [{dep: dep, 'default': is_default} 
+          for dep, is_default in 
+          zip(get_possible_dependencies(), get_is_default_from_choices())
+      ]
     default:
       code: |
         get_is_default_from_choices
@@ -425,12 +428,15 @@ code: |
 ---
 code: |
   # Build the list of includes
+  include_data = {
+    "includes": ['docassemble.AssemblyLine:al_package.yml'] + \
+        get_yml_deps_from_choices(
+            interview.dependency_choices.true_values())
+  }
   include_question = interview.blocks.appendObject()
   include_question.template_key = 'include'
-  include_question.data = {
-    "includes": ['docassemble.AssemblyLine:al_package.yml'] + 
-        get_yml_deps_from_choices(interview.dependency_choices.true_values())
-    }
+  include_question.data = include_data
+  del include_data
   add_includes = True
 ---
 code: |

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -202,10 +202,13 @@ fields:
   - no label: interview.dependency_choices
     datatype: checkboxes
     required: False
-    choices:
+    code:
+      get_possible_dependencies()
       - Massachusetts State: docassemble.ALMassachusetts>=0.0.7
       - MassAccess: docassemble.MassAccess
     default:
+      code: |
+        get_is_default_from_choices
       - docassemble.ALMassachusetts>=0.0.7
       - docassemble.MassAccess
 ---
@@ -427,10 +430,9 @@ code: |
   # Build the list of includes
   include_question = interview.blocks.appendObject()
   include_question.template_key = 'include'
-  # TODO: add a graphical element to select something other than
-  # massaccess.yml
   include_question.data = {
-    "includes": ['docassemble.AssemblyLine:al_package.yml', 'docassemble.MassAccess:massaccess.yml']
+    "includes": ['docassemble.AssemblyLine:al_package.yml'] + 
+        get_yml_dep_from_choices(interview.dependency_choices.true_values()
     }
   add_includes = True
 ---
@@ -1019,7 +1021,7 @@ code: |
   }
   
   create_package_zip(package_title,
-        interview.package_info(interview.dependency_choices.true_values()),
+        interview.package_info(get_pypi_dep_from_choices(interview.dependency_choices)),
         {"author name and email":"author@example.com"},
         folders_and_files, 
         interview_package_download)

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -8,10 +8,11 @@ features:
   # labels above fields: True
 ---
 modules:
+  - collections
   - docassemble.base.util
   - docassemble.base.logger
   - .interview_generator
-  - collections
+  - .custom_values
 ---
 features:
   css: progressivedisclosure.css  
@@ -204,13 +205,9 @@ fields:
     required: False
     code:
       get_possible_dependencies()
-      - Massachusetts State: docassemble.ALMassachusetts>=0.0.7
-      - MassAccess: docassemble.MassAccess
     default:
       code: |
         get_is_default_from_choices
-      - docassemble.ALMassachusetts>=0.0.7
-      - docassemble.MassAccess
 ---
 code: |    
   if not interview.court_related:   
@@ -432,7 +429,7 @@ code: |
   include_question.template_key = 'include'
   include_question.data = {
     "includes": ['docassemble.AssemblyLine:al_package.yml'] + 
-        get_yml_dep_from_choices(interview.dependency_choices.true_values()
+        get_yml_deps_from_choices(interview.dependency_choices.true_values())
     }
   add_includes = True
 ---
@@ -1021,7 +1018,7 @@ code: |
   }
   
   create_package_zip(package_title,
-        interview.package_info(get_pypi_dep_from_choices(interview.dependency_choices)),
+        interview.package_info(get_pypi_deps_from_choices(interview.dependency_choices)),
         {"author name and email":"author@example.com"},
         folders_and_files, 
         interview_package_download)

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -196,21 +196,20 @@ question: Which jurisdictions and organizations is this form a part of?
 subquestion: |
   This will add those jurisdictions as dependencies. If you are unsure, leave the default options checked.
 help:
-  label: My jurisdiction is not here
+  label: My jurisdiction or organization is not here
   content: |
     New jurisdictions will be added soon. You should add those dependencies manually in the Playground until then.
 fields:
-  - no label: interview.dependency_choices
+  - Jurisdictions: interview.jurisdiction_choices
     datatype: checkboxes
     required: False
     code: |
-      [{dep: dep, 'default': is_default} 
-          for dep, is_default in 
-          zip(get_possible_dependencies(), get_is_default_from_choices())
-      ]
-    default:
-      code: |
-        get_is_default_from_choices
+      get_possible_deps_as_choices('jurisdiction')
+  - Organizations: interview.org_choices
+    datatype: checkboxes
+    required: False
+    code: |
+      get_possible_deps_as_choices('organization')
 ---
 code: |    
   if not interview.court_related:   
@@ -431,7 +430,8 @@ code: |
   include_data = {
     "includes": ['docassemble.AssemblyLine:al_package.yml'] + \
         get_yml_deps_from_choices(
-            interview.dependency_choices.true_values())
+            interview.jurisdiction_choices.true_values() +
+            interview.org_choices.true_values())
   }
   include_question = interview.blocks.appendObject()
   include_question.template_key = 'include'
@@ -1024,7 +1024,12 @@ code: |
   }
   
   create_package_zip(package_title,
-        interview.package_info(get_pypi_deps_from_choices(interview.dependency_choices)),
+        interview.package_info(
+          get_pypi_deps_from_choices(
+            interview.jurisdiction_choices.true_values() +
+            interview.org_choices.true_values()
+          )
+        ),
         {"author name and email":"author@example.com"},
         folders_and_files, 
         interview_package_download)


### PR DESCRIPTION
Does three things:
* splits the dependency question into "jurisdiction" and "organization"
* puts the selected dependencies into the `include` block
* Sets up the ability to read dependency information from an installation specific yaml file in the `sources` dir. Future work there will be a write an interview that writes that file with github organization info, extra dependencies to possible add, defaults, and eventually, things from `generator_constants.py` like Court types.

The yaml stuff seems a bit hacky, but only because of docassemble's persistent files in packages and playground vs installation differences.