### PR TITLE
Add pdf safety

### DIFF
--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -40,6 +40,7 @@ code: |
   template_upload
   # Run pdf_field_tester.yml if form is a pdf.  
   if template_upload[0].filename.endswith('pdf'):
+    validate_pdf
     field_list_display
     pdf_check_display
   interview.form_type
@@ -380,6 +381,10 @@ comment: |
   Get the list of fields, and check for any possible labeling errors
   right away
 code: |
+  from pdfminer.pdfparser import PDFSyntaxError
+  from PyPDF2.utils import PdfReadError
+  from zipfile import BadZipFile
+  
   try:
     if template_upload[0].extension == 'pdf':
       all_fields = get_pdf_fields(template_upload)
@@ -387,17 +392,31 @@ code: |
       all_fields = get_fields(template_upload)
       
     if all_fields is None:
-      force_ask('empty_pdf')
+      empty_pdf
 
     bad_fields = list(filter(
         lambda elem: elem is not None, 
         map(bad_name_reason, all_fields)))
     if len(bad_fields) > 0:
-      force_ask('non_descriptive_field_name')
+      non_descriptive_field_name
       
   except ParsingException as ex:
     parsing_ex = ex
-    force_ask('parsing_exception')
+    parsing_exception
+  
+  except (PDFSyntaxError, PdfReadError, BadZipFile):
+    # Handle PDF read error
+    exit_invalid_file  
+---
+event: exit_invalid_file
+question: |
+  Is this a valid file?
+subquestion: |
+  Docassemble was not able to read the file you uploaded.
+  
+  Make sure it is a valid document.
+buttons:
+  - Restart: restart
 ---
 code: |
  built_in_people_vars_used = get_person_variables(all_fields, custom_only=False) - get_person_variables(all_fields, custom_only=True)

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -399,22 +399,39 @@ code: |
         map(bad_name_reason, all_fields)))
     if len(bad_fields) > 0:
       non_descriptive_field_name
-      
   except ParsingException as ex:
     parsing_ex = ex
-    parsing_exception
-  
-  except (PDFSyntaxError, PdfReadError, BadZipFile):
+    force_ask('parsing_exception')
+  except (PDFSyntaxError, PdfReadError):
     # Handle PDF read error
-    exit_invalid_file  
+    force_ask('exit_invalid_pdf')
+  except (BadZipFile, KeyError):
+    force_ask('exit_invalid_docx')
 ---
-event: exit_invalid_file
+event: exit_invalid_pdf
 question: |
-  Is this a valid file?
+  Is this a valid PDF?
 subquestion: |
-  Docassemble was not able to read the file you uploaded.
+  ${ template_upload[0].filename } does not seem to be a PDF file. Usually
+  this error happens because the file is corrupt or has the wrong extension.
+
+  Docassemble was not able to read the file you uploaded. Make sure it is a
+  valid document.
   
-  Make sure it is a valid document.
+  If it is a PDF, try using [documate.org/pdf](https://www.documate.org/pdf)
+  or [qpdf](http://qpdf.sourceforge.net/) to fix it.
+buttons:
+  - Restart: restart
+---
+event: exit_invalid_docx
+question: |
+  Is this a valid DOCX file?
+subquestion: |
+  ${ template_upload[0].filename } does not seem to be a DOCX file. Usually
+  this error happens because the file is corrupt or has the wrong extension.
+
+  Docassemble was not able to read the file you uploaded. Make sure it is a
+  valid document.
 buttons:
   - Restart: restart
 ---

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -391,7 +391,7 @@ code: |
     else:
       all_fields = get_fields(template_upload)
       
-    if all_fields is None:
+    if not all_fields:
       empty_pdf
 
     bad_fields = list(filter(

--- a/docassemble/assemblylinewizard/data/questions/assembly_line.yml
+++ b/docassemble/assemblylinewizard/data/questions/assembly_line.yml
@@ -392,13 +392,13 @@ code: |
       all_fields = get_fields(template_upload)
       
     if not all_fields:
-      empty_pdf
+      force_ask('empty_pdf')
 
     bad_fields = list(filter(
         lambda elem: elem is not None, 
         map(bad_name_reason, all_fields)))
     if len(bad_fields) > 0:
-      non_descriptive_field_name
+      force_ask('non_descriptive_field_name')
   except ParsingException as ex:
     parsing_ex = ex
     force_ask('parsing_exception')

--- a/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
+++ b/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
@@ -240,9 +240,9 @@ code: |
     pdf_concatenate(test_assemble_pdf)
   except PDFSyntaxError:
     # Handle PDF read error
-    exit_invalid_file
+    force_ask('exit_invalid_file')
   except PdfReadError:
-    exit_xref_table
+    force_ask('exit_xref_table')
   except:
     pass # Continue on to safer checks with get_pdf_fields
   validate_pdf = True
@@ -261,12 +261,3 @@ subquestion: |
   more](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs).
 buttons:
   - Restart: restart
----
-event: exit_something_went_wrong
-question: |
-  Something went wrong reading your template
-subquestion: |
-  Are you sure this is a valid document?
-buttons:
-  - Restart: restart
-  

--- a/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
+++ b/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
@@ -224,20 +224,12 @@ attachment:
   code: |
     pdf_fields
 ---
-attachment:
-  variable name: test_assemble_pdf
-  pdf template file:
-    code: |
-      template_upload
-  fields:
-    - "Field1": "Value1"
----
 code: |
   from pdfminer.pdfparser import PDFSyntaxError
   from PyPDF2.utils import PdfReadError
 
   try:
-    pdf_concatenate(test_assemble_pdf)
+    pdf_concatenate(template_upload)
   except PDFSyntaxError:
     # Handle PDF read error
     force_ask('exit_invalid_file')

--- a/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
+++ b/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
@@ -242,22 +242,9 @@ code: |
     # Handle PDF read error
     exit_invalid_file
   except PdfReadError:
-    exit_livecycle_pdf
-  except:
-    exit_something_went_wrong
-  validate_pdf = True
----
-code: |
-  from pdfminer.pdfparser import PDFSyntaxError
-  from PyPDF2.utils import PdfReadError
- 
-  try:
-    pdf_concatenate(template_upload)
-  except PDFSyntaxError:
-    # Handle PDF read error
-    exit_invalid_file
-  except PdfReadError:
     exit_xref_table
+  except:
+    pass # Continue on to safer checks with get_pdf_fields
   validate_pdf = True
 ---
 event: exit_xref_table

--- a/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
+++ b/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
@@ -217,3 +217,63 @@ attachment:
       template_upload
   code: |
     pdf_fields
+---
+attachment:
+  variable name: test_assemble_pdf
+  pdf template file:
+    code: |
+      template_upload
+  fields:
+    - "Field1": "Value1"
+---
+code: |
+  from pdfminer.pdfparser import PDFSyntaxError
+  from PyPDF2.utils import PdfReadError
+
+  try:
+    pdf_concatenate(test_assemble_pdf)
+  except PDFSyntaxError:
+    # Handle PDF read error
+    exit_invalid_file
+  except PdfReadError:
+    exit_livecycle_pdf
+  except:
+    exit_something_went_wrong
+  validate_pdf = True
+---
+code: |
+  from pdfminer.pdfparser import PDFSyntaxError
+  from PyPDF2.utils import PdfReadError
+ 
+  try:
+    pdf_concatenate(template_upload)
+  except PDFSyntaxError:
+    # Handle PDF read error
+    exit_invalid_file
+  except PdfReadError:
+    exit_xref_table
+  validate_pdf = True
+---
+event: exit_xref_table
+question: |
+  This PDF is not valid
+subquestion: |
+  There was a problem reading this PDF.
+  
+  Sometimes you can fix this problem by using 
+  [documate.org/pdf](https://www.documate.org/pdf) or by using 
+  [qpdf](http://qpdf.sourceforge.net/).
+  
+  [Read 
+  more](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs#corrupted-or-locked-pdfs).
+buttons:
+  - Restart: restart
+---
+event: exit_something_went_wrong
+question: |
+  Something went wrong reading your template
+subquestion: |
+  Are you sure this is a valid document?
+buttons:
+  - Restart: restart
+  

--- a/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
+++ b/docassemble/assemblylinewizard/data/questions/pdf_field_tester.yml
@@ -29,12 +29,18 @@ code: |
 event: empty_pdf
 question: You uploaded an empty PDF
 subquestion: |
-  The PDF you uploaded (${ template_upload[0].filename }) does not have any fillable fields.
-  To make a new interview with the Weaver, we need to have a document that has fillable fields.
+  The PDF you uploaded (${ template_upload[0].filename }) does not have any 
+  fillable fields. To make a new interview with the Weaver, we need to have a 
+  document that has fillable fields.
   
-  If you saved a DOCX file as a PDF, you will need to add fillable fields in a tool like [Adobe Acrobat](https://acrobat.adobe.com). 
+  If you saved a DOCX file as a PDF, you will need to add fillable fields in a 
+  tool like [Adobe Acrobat](https://acrobat.adobe.com). 
   For more info, see the [documentation](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/pdfs).
 
+  If you uploaded a form that can only be opened in Adobe Acrobat (a LiveCycle
+  or XFA form), you may need to flatten it first. You can flatten an XFA form
+  using [iText PDF's free 
+  tool](https://itextpdf.com/en/demos/flatten-dynamic-xfa-pdf-free-online).
 buttons:
   - Restart: restart
 ---

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -21,7 +21,6 @@ import ruamel.yaml as yaml
 import mako.template
 import mako.runtime
 from pdfminer.pdftypes import PDFObjRef, resolve1
-from collections.abc import Iterable
 
 mako.runtime.UNDEFINED = DAEmpty()
 

--- a/docassemble/assemblylinewizard/interview_generator.py
+++ b/docassemble/assemblylinewizard/interview_generator.py
@@ -20,6 +20,8 @@ from .custom_values import custom_values
 import ruamel.yaml as yaml
 import mako.template
 import mako.runtime
+from pdfminer.pdftypes import PDFObjRef, resolve1
+from collections.abc import Iterable
 
 mako.runtime.UNDEFINED = DAEmpty()
 
@@ -816,12 +818,12 @@ def get_pdf_fields(the_file):
   all_fields = docassemble.base.pdftk.read_fields(the_file.path())
   if all_fields is None:
     return None
-  for item in docassemble.base.pdftk.read_fields(the_file.path()):
-    the_type = re.sub(r'[^/A-Za-z]', '', str(item[4]))
+  for field in all_fields:
+    the_type = re.sub(r'[^/A-Za-z]', '', str(field[4]))
     if the_type == 'None':
       the_type = None
-    result = (item[0], '' if item[1] == 'something' else item[1], item[2], item[3], the_type, item[5])
-    results.append(result)
+    result = (field[0], '' if field[1] == 'something' else field[1], field[2], field[3], the_type, field[5])
+    results.append(tuple(map(shim_remove_pdf_obj_refs,result)))
   return results
 
 def get_fields(the_file):
@@ -830,15 +832,35 @@ def get_fields(the_file):
   has a valid and exiting filepath."""
   if isinstance(the_file, DAFileList):
     if the_file[0].mimetype == 'application/pdf':
-      return [field[0] for field in the_file[0].get_pdf_fields()]
+      return [shim_remove_pdf_obj_refs(field[0]) for field in the_file[0].get_pdf_fields()]
   else:
     if the_file.mimetype == 'application/pdf':
-      return [field[0] for field in the_file.get_pdf_fields()]
+      return [shim_remove_pdf_obj_refs(field[0]) for field in the_file.get_pdf_fields()]
 
   docx_data = docx2python( the_file.path() )  # Will error with invalid value
   text = docx_data.text
   return get_docx_variables( text )
 
+def shim_remove_pdf_obj_refs(value):
+  """
+  Recursively process PDF fields with unresolved PDFObjRefs so that they can be pickled and also
+  so that we can determine max char length.
+  
+  TODO: unneeded if https://github.com/jhpyle/docassemble/pull/413 is merged.
+  """
+  if isinstance(value, PDFObjRef):
+    temp_val = resolve1(value)
+    if isinstance(temp_val, list): # I think only options are lists, PDFObjRefs, or base types
+      temp_list = []
+      for val in temp_val:
+        if isinstance(val, PDFObjRef):
+          temp_list.append(shim_remove_pdf_obj_refs(val))
+        else:
+          temp_list.append(val)
+      return temp_list
+    return temp_val
+  return value
+      
 
 def get_docx_variables( text:str )->set:
   """


### PR DESCRIPTION
Fix #401 and add a few other safety checks:

* Invalid Xref table
* PDF cannot be concatenated
* PDFs with unusual field tuples
* Warn about XFA forms (all_fields is an empty list instead of None)

Some of these may be obsoleted by upstream fixes, but this will offer a little safety for people on older docassemble versions.

Some files that will give helpful error messages:

* [Fax_cover_sheet_corrupt.pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/6581278/Fax_cover_sheet_corrupt.pdf)
* [not_a_pdf.pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/6581281/not_a_pdf.pdf)
* [ma_seal_criminal_records(1).pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/6581279/ma_seal_criminal_records.1.pdf)
* [MRV_Single.2.1(1).pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/6581280/MRV_Single.2.1.1.pdf)
* [single_field_corrupted.docx](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/6581282/single_field_corrupted.docx)
* [sample_xfa_no_acroform (not fillable in docassemble).pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/6581283/sample_xfa_no_acroform.not.fillable.in.docassemble.pdf)

Some PDFs that will work:

* [pdf_obj_refs-should work.pdf](https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/files/6581286/pdf_obj_refs-should.work.pdf)

